### PR TITLE
Add WebSocket server library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# WebSocket Server Library
+
+## Building
+
+This project requires an SSL version flag because it depends on the `ssl` package for SHA-1 (handshake accept key computation).
+
+```
+make test ssl=3.0.x          # Build + run tests + build examples
+make unit-tests ssl=3.0.x    # Just tests
+make build-examples ssl=3.0.x # Just examples
+```
+
+## Dependencies
+
+- **lori** (0.8.5) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
+- **ssl** (2.0.0) — SHA-1 digest for computing the WebSocket handshake accept key (`ssl/crypto`). Also provides `ssl/net` for WSS (TLS) support.
+- **stdlib encode/base64** — Base64 encoding for the handshake accept key.
+
+Import aliases used consistently across the codebase:
+- `use lori = "lori"`
+- `use crypto = "ssl/crypto"`
+- `use ssl_net = "ssl/net"` (only in `websocket_server.pony`)
+- `use "encode/base64"` (unqualified)
+
+## Architecture
+
+Follows lori/stallion's "your actor IS the connection" pattern. Users implement two actors:
+
+1. **Listener actor** — implements `lori.TCPListenerActor`, accepts connections, creates handler actors.
+2. **Handler actor** — implements `WebSocketServerActor` (which combines `lori.TCPConnectionActor` + `WebSocketLifecycleEventReceiver`). Each handler owns a `WebSocketServer` protocol handler instance.
+
+`WebSocketServer` is a class (not an actor) that implements `lori.ServerLifecycleEventReceiver`. It owns the state machine, parsers, and frame encoder. All protocol logic runs synchronously within the handler actor's context.
+
+## State Machine
+
+Four states, implemented as a trait (`_ConnectionState`) with concrete state classes. Every state handles every event — the state machine is the single place to understand behavior.
+
+```
+_Handshaking → _Open → _Closing → _Closed
+                 ↓                    ↑
+                 └────────────────────┘
+                 (error / abnormal close)
+```
+
+- **`_Handshaking`**: Buffers HTTP upgrade request via `_HandshakeParser`. On success, sends 101 response, transitions to `_Open`. On error, sends HTTP error, closes TCP.
+- **`_Open`**: Parses WebSocket frames via `_FrameParser`, reassembles fragments via `_FragmentReassembler`. Handles ping/pong automatically. Delivers text/binary messages to user callbacks.
+- **`_Closing`**: Server initiated close, waiting for client's close response. Only processes close and control frames; data frames are discarded.
+- **`_Closed`**: Terminal state, all operations are no-ops.
+
+## Internal Components
+
+| File | Type | Purpose |
+|------|------|---------|
+| `_handshake_parser.pony` | `_HandshakeParser` | Buffers and parses HTTP upgrade request, validates WebSocket headers, computes accept key |
+| `_frame_parser.pony` | `_FrameParser` | Incremental WebSocket frame parser with masking, length decoding, validation |
+| `_frame_encoder.pony` | `_FrameEncoder` | Builds outgoing server frames (never masked) |
+| `_fragment_reassembler.pony` | `_FragmentReassembler` | Reassembles fragmented messages, enforces size limits, validates UTF-8 for text |
+| `_utf8_validator.pony` | `_Utf8Validator` | UTF-8 byte sequence validation |
+| `_connection_state.pony` | `_ConnectionState` | State machine trait + four state classes |
+| `_mort.pony` | `_Unreachable` | Crash-on-bug helper for impossible code paths |
+
+## Naming Conventions
+
+- `_` prefix on type names = package-private (visible within `websockets/` package, not to consumers)
+- `_` prefix on members = type-private (only accessible within the defining type)
+- File names match the primary type they contain (e.g., `websocket_server.pony` contains `WebSocketServer`)
+
+## Test Patterns
+
+Tests are in `websockets/_test*.pony` files, registered in `_test.pony`. Mix of:
+- **Example-based unit tests** for specific scenarios (valid input, each error case, boundary conditions)
+- **PonyCheck property tests** for invariants over generated inputs (roundtrip encoding, valid input acceptance, fragment reassembly)
+
+Tests run sequentially with `--exclude=integration` (no integration tests in v1).
+
+## Design Decisions
+
+- **Close timeout deferred**: The design specifies a close handshake timeout, but it's omitted from v1. Lori's idle timeout resets on any TCP receive, making it unreliable for close timeouts. OS TCP timeout handles the degenerate case.
+- **Send errors silently dropped**: `_tcp_connection.send()` errors (`SendErrorNotConnected`, `SendErrorNotWriteable`) are ignored — the library can't do anything useful in either case.
+- **No integration tests in v1**: Unit tests cover parsing, encoding, and reassembly. Integration tests requiring TCP connections are deferred.

--- a/corral.json
+++ b/corral.json
@@ -10,5 +10,14 @@
     "version": "0.0.0",
     "name": "websockets"
   },
-  "deps": []
+  "deps": [
+    {
+      "locator": "github.com/ponylang/lori.git",
+      "version": "0.8.5"
+    },
+    {
+      "locator": "github.com/ponylang/ssl.git",
+      "version": "2.0.0"
+    }
+  ]
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+## echo
+
+A WebSocket echo server that echoes back text and binary messages. Listens on `ws://localhost:8080`. Connect with any WebSocket client (e.g., `websocat ws://localhost:8080`) and send messages to see them echoed back.

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -1,6 +1,0 @@
-"""
-Placeholder for a basic WebSocket example.
-"""
-actor Main
-  new create(env: Env) =>
-    env.out.print("WebSocket example (not yet implemented)")

--- a/examples/echo/main.pony
+++ b/examples/echo/main.pony
@@ -1,0 +1,72 @@
+"""
+A WebSocket echo server that echoes back text and binary messages.
+
+Connect with any WebSocket client (e.g., websocat, browser JS) to
+ws://localhost:8080 and messages will be echoed back.
+"""
+use lori = "lori"
+use ws = "../../websockets"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+    let config = ws.WebSocketConfig(where
+      host' = "localhost",
+      port' = "8080")
+    EchoListener(auth, config, env.out)
+
+actor EchoListener is lori.TCPListenerActor
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _server_auth: lori.TCPServerAuth
+  let _config: ws.WebSocketConfig val
+  let _out: OutStream
+
+  new create(
+    auth: lori.TCPListenAuth,
+    config: ws.WebSocketConfig val,
+    out: OutStream)
+  =>
+    _server_auth = lori.TCPServerAuth(auth)
+    _config = config
+    _out = out
+    _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
+
+  fun ref _listener(): lori.TCPListener => _tcp_listener
+
+  fun ref _on_accept(fd: U32): EchoHandler =>
+    EchoHandler(_server_auth, fd, _config, _out)
+
+  fun ref _on_listening() =>
+    _out.print("Listening on " + _config.host + ":" + _config.port)
+
+  fun ref _on_listen_failure() =>
+    _out.print("Failed to listen on " + _config.host + ":" + _config.port)
+
+actor EchoHandler is ws.WebSocketServerActor
+  var _ws: ws.WebSocketServer = ws.WebSocketServer.none()
+  let _out: OutStream
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ws.WebSocketConfig val,
+    out: OutStream)
+  =>
+    _out = out
+    _ws = ws.WebSocketServer(auth, fd, this, config)
+
+  fun ref _websocket(): ws.WebSocketServer => _ws
+
+  fun ref on_open(request: ws.UpgradeRequest val) =>
+    _out.print("Client connected: " + request.uri)
+
+  fun ref on_text_message(data: String val) =>
+    _out.print("Text: " + data)
+    _ws.send_text(data)
+
+  fun ref on_binary_message(data: Array[U8] val) =>
+    _out.print("Binary: " + data.size().string() + " bytes")
+    _ws.send_binary(data)
+
+  fun ref on_closed() =>
+    _out.print("Client disconnected")

--- a/websockets/_connection_state.pony
+++ b/websockets/_connection_state.pony
@@ -1,0 +1,149 @@
+use lori = "lori"
+
+trait val _ConnectionState
+  """
+  Connection lifecycle state.
+
+  Dispatches WebSocket events to the appropriate server methods based on
+  what operations are valid in each state. Four states:
+  `_Handshaking` (parsing HTTP upgrade), `_Open` (exchanging messages),
+  `_Closing` (server initiated close, awaiting client response), and
+  `_Closed` (all operations are no-ops).
+  """
+
+  fun on_received(server: WebSocketServer ref, data: Array[U8] iso)
+    """Handle incoming data from the TCP connection."""
+
+  fun on_closed(server: WebSocketServer ref)
+    """Handle connection close notification."""
+
+  fun on_throttled(server: WebSocketServer ref)
+    """Handle backpressure applied notification."""
+
+  fun on_unthrottled(server: WebSocketServer ref)
+    """Handle backpressure released notification."""
+
+  fun on_sent(server: WebSocketServer ref, token: lori.SendToken)
+    """Handle send completion notification from lori."""
+
+  fun on_idle_timeout(server: WebSocketServer ref)
+    """Handle connection going idle."""
+
+  fun send_text(server: WebSocketServer ref, data: String val)
+    """Send a text message."""
+
+  fun send_binary(server: WebSocketServer ref, data: Array[U8] val)
+    """Send a binary message."""
+
+  fun close(
+    server: WebSocketServer ref,
+    code: CloseCode,
+    reason: String val)
+    """Initiate a close handshake."""
+
+primitive _Handshaking is _ConnectionState
+  """Parsing the HTTP upgrade request. No WebSocket messages yet."""
+
+  fun on_received(server: WebSocketServer ref, data: Array[U8] iso) =>
+    server._feed_handshake(consume data)
+
+  fun on_closed(server: WebSocketServer ref) =>
+    // Handshake never completed — no user callbacks
+    server._set_state(_Closed)
+
+  fun on_throttled(server: WebSocketServer ref) => None
+  fun on_unthrottled(server: WebSocketServer ref) => None
+  fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
+  fun on_idle_timeout(server: WebSocketServer ref) => None
+  fun send_text(server: WebSocketServer ref, data: String val) => None
+  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) => None
+
+  fun close(
+    server: WebSocketServer ref,
+    code: CloseCode,
+    reason: String val)
+  =>
+    None
+
+primitive _Open is _ConnectionState
+  """WebSocket connection is open — exchanging messages."""
+
+  fun on_received(server: WebSocketServer ref, data: Array[U8] iso) =>
+    server._feed_frames(consume data)
+
+  fun on_closed(server: WebSocketServer ref) =>
+    // Abnormal TCP close
+    server._fire_on_closed()
+    server._set_state(_Closed)
+
+  fun on_throttled(server: WebSocketServer ref) =>
+    server._fire_on_throttled()
+
+  fun on_unthrottled(server: WebSocketServer ref) =>
+    server._fire_on_unthrottled()
+
+  fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
+  fun on_idle_timeout(server: WebSocketServer ref) => None
+
+  fun send_text(server: WebSocketServer ref, data: String val) =>
+    server._send_frame(_FrameEncoder.text(data))
+
+  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) =>
+    server._send_frame(_FrameEncoder.binary(data))
+
+  fun close(
+    server: WebSocketServer ref,
+    code: CloseCode,
+    reason: String val)
+  =>
+    server._send_frame(_FrameEncoder.close(code, reason))
+    server._set_state(_Closing)
+
+primitive _Closing is _ConnectionState
+  """
+  Server initiated close, waiting for client's close response.
+
+  Data frames are discarded. Control frames are still processed:
+  ping gets a pong, pong is ignored, close completes the handshake.
+  """
+
+  fun on_received(server: WebSocketServer ref, data: Array[U8] iso) =>
+    server._feed_frames_closing(consume data)
+
+  fun on_closed(server: WebSocketServer ref) =>
+    // TCP dropped before close response
+    server._fire_on_closed()
+    server._set_state(_Closed)
+
+  fun on_throttled(server: WebSocketServer ref) => None
+  fun on_unthrottled(server: WebSocketServer ref) => None
+  fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
+  fun on_idle_timeout(server: WebSocketServer ref) => None
+  fun send_text(server: WebSocketServer ref, data: String val) => None
+  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) => None
+
+  fun close(
+    server: WebSocketServer ref,
+    code: CloseCode,
+    reason: String val)
+  =>
+    None
+
+primitive _Closed is _ConnectionState
+  """Connection is closed — all operations are no-ops."""
+
+  fun on_received(server: WebSocketServer ref, data: Array[U8] iso) => None
+  fun on_closed(server: WebSocketServer ref) => None
+  fun on_throttled(server: WebSocketServer ref) => None
+  fun on_unthrottled(server: WebSocketServer ref) => None
+  fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
+  fun on_idle_timeout(server: WebSocketServer ref) => None
+  fun send_text(server: WebSocketServer ref, data: String val) => None
+  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) => None
+
+  fun close(
+    server: WebSocketServer ref,
+    code: CloseCode,
+    reason: String val)
+  =>
+    None

--- a/websockets/_fragment_reassembler.pony
+++ b/websockets/_fragment_reassembler.pony
@@ -1,0 +1,99 @@
+class _FragmentReassembler
+  """
+  Reassembles fragmented WebSocket messages.
+
+  Buffers continuation frames until the final fragment arrives, enforces
+  `max_message_size`, and validates UTF-8 for text messages. Control
+  frames (ping, pong, close) bypass this class entirely — the caller
+  dispatches them before reaching the reassembler.
+  """
+  var _in_progress: Bool = false
+  var _is_text: Bool = false
+  var _buf: Array[U8] ref = Array[U8]
+  var _total_size: USize = 0
+
+  fun ref frame(
+    fin: Bool,
+    opcode: U8,
+    payload: Array[U8] val,
+    max_size: USize)
+    : (_CompleteMessage | _FragmentContinue | _ReassemblyError)
+  =>
+    """
+    Process a data frame (text, binary, or continuation).
+
+    Returns `_CompleteMessage` when the full message is assembled,
+    `_FragmentContinue` when more fragments are expected, or
+    `_ReassemblyError` on protocol violation.
+    """
+    if opcode == 0x00 then
+      // Continuation frame
+      if not _in_progress then
+        return _ReassemblyError(CloseProtocolError)
+      end
+    else
+      // Text (0x01) or binary (0x02) — starts a new message
+      if _in_progress then
+        return _ReassemblyError(CloseProtocolError)
+      end
+      _in_progress = true
+      _is_text = (opcode == 0x01)
+      _buf = Array[U8]
+      _total_size = 0
+    end
+
+    // Accumulate payload
+    _total_size = _total_size + payload.size()
+    if _total_size > max_size then
+      _reset()
+      return _ReassemblyError(CloseMessageTooBig)
+    end
+    _buf.append(payload)
+
+    if fin then
+      // Message complete. Build val array from buffer using String
+      // intermediary: build ref String, clone to iso, iso_array to val.
+      let is_text' = _is_text
+      let msg_s = String(_buf.size())
+      for b in _buf.values() do
+        msg_s.push(b)
+      end
+      let message_data: Array[U8] val = msg_s.clone().iso_array()
+      _reset()
+
+      if is_text' then
+        if not _Utf8Validator.is_valid(message_data) then
+          return _ReassemblyError(CloseInvalidPayload)
+        end
+      end
+
+      _CompleteMessage(is_text', message_data)
+    else
+      _FragmentContinue
+    end
+
+  fun ref _reset() =>
+    """Reset reassembly state for the next message."""
+    _in_progress = false
+    _is_text = false
+    _buf = Array[U8]
+    _total_size = 0
+
+class val _CompleteMessage
+  """A fully reassembled WebSocket message."""
+  let is_text: Bool
+  let data: Array[U8] val
+
+  new val create(is_text': Bool, data': Array[U8] val) =>
+    is_text = is_text'
+    data = data'
+
+primitive _FragmentContinue
+  """More fragments are expected to complete the message."""
+
+class val _ReassemblyError
+  """A reassembly error with the close code to send."""
+  let code: CloseCode
+
+  new val create(code': CloseCode) =>
+    code = code'

--- a/websockets/_frame_encoder.pony
+++ b/websockets/_frame_encoder.pony
@@ -1,0 +1,84 @@
+primitive _FrameEncoder
+  """
+  Builds outgoing WebSocket frames (server-to-client, never masked).
+
+  All methods return a complete frame as a `val` byte array ready to
+  send over TCP.
+  """
+
+  fun text(data: String val): Array[U8] val =>
+    """Encode a text message frame (FIN=1, opcode=0x1)."""
+    _encode(true, 0x01, data)
+
+  fun binary(data: Array[U8] val): Array[U8] val =>
+    """Encode a binary message frame (FIN=1, opcode=0x2)."""
+    _encode(true, 0x02, data)
+
+  fun close(code: CloseCode, reason: String val = ""): Array[U8] val =>
+    """Encode a close frame with a status code and optional reason."""
+    let code_val = code.code()
+    let payload = recover iso
+      let p = Array[U8](2 + reason.size())
+      p.>push((code_val >> 8).u8())
+        .>push((code_val and 0xFF).u8())
+      p.append(reason)
+      p
+    end
+    _encode(true, 0x08, consume payload)
+
+  fun close_payload(payload: Array[U8] val): Array[U8] val =>
+    """Encode a close frame echoing back the client's raw close payload."""
+    _encode(true, 0x08, payload)
+
+  fun close_empty(): Array[U8] val =>
+    """Encode a close frame with no payload."""
+    _encode(true, 0x08, recover val Array[U8] end)
+
+  fun pong(data: Array[U8] val): Array[U8] val =>
+    """Encode a pong frame echoing the ping payload."""
+    _encode(true, 0x0A, data)
+
+  fun _encode(fin: Bool, opcode: U8, payload: ByteSeq): Array[U8] val =>
+    """
+    Build a complete frame with the given FIN bit, opcode, and payload.
+
+    Server-to-client frames are never masked (RFC 6455 Section 5.1).
+    Payload length uses the appropriate encoding: 7-bit for 0..125,
+    16-bit for 126..65535, 64-bit for larger.
+    """
+    let payload_size = payload.size()
+    let header_size: USize =
+      if payload_size <= 125 then 2
+      elseif payload_size <= 65535 then 4
+      else 10
+      end
+
+    recover val
+      let frame = Array[U8](header_size + payload_size)
+
+      // First byte: FIN + opcode
+      let first: U8 = if fin then 0x80 or opcode else opcode end
+      frame.push(first)
+
+      // Second byte: MASK=0 + payload length
+      if payload_size <= 125 then
+        frame.push(payload_size.u8())
+      elseif payload_size <= 65535 then
+        frame.push(126)
+        frame.>push((payload_size >> 8).u8())
+          .push((payload_size and 0xFF).u8())
+      else
+        frame.push(127)
+        frame.>push((payload_size >> 56).u8())
+          .>push(((payload_size >> 48) and 0xFF).u8())
+          .>push(((payload_size >> 40) and 0xFF).u8())
+          .>push(((payload_size >> 32) and 0xFF).u8())
+          .>push(((payload_size >> 24) and 0xFF).u8())
+          .>push(((payload_size >> 16) and 0xFF).u8())
+          .>push(((payload_size >> 8) and 0xFF).u8())
+          .push((payload_size and 0xFF).u8())
+      end
+
+      frame.append(payload)
+      frame
+    end

--- a/websockets/_frame_parser.pony
+++ b/websockets/_frame_parser.pony
@@ -1,0 +1,190 @@
+class _FrameParser
+  """
+  Incremental WebSocket frame parser.
+
+  Accumulates incoming bytes and parses complete frames. Handles masking,
+  validates frame structure per RFC 6455, and returns unmasked payloads.
+  """
+  var _buf: Array[U8] ref = Array[U8]
+
+  fun ref parse(data: Array[U8] val)
+    : (Array[_ParsedFrame val] val | _FrameError)
+  =>
+    """
+    Feed data and parse all complete frames.
+
+    Returns an array of parsed frames, or a `_FrameError` for the first
+    protocol violation encountered.
+    """
+    _buf.append(data)
+
+    let frames = recover iso Array[_ParsedFrame val] end
+
+    while _buf.size() > 0 do
+      match _try_parse_frame()
+      | let frame: _ParsedFrame val =>
+        frames.push(frame)
+      | let err: _FrameError =>
+        return err
+      | None =>
+        break
+      end
+    end
+
+    consume frames
+
+  fun ref _try_parse_frame(): (_ParsedFrame val | _FrameError | None) =>
+    """Attempt to parse a single frame from the buffer."""
+    if _buf.size() < 2 then return None end
+
+    try
+      let b0 = _buf(0)?
+      let b1 = _buf(1)?
+
+      let fin = (b0 and 0x80) != 0
+      let rsv = (b0 and 0x70)
+      let opcode = b0 and 0x0F
+      let masked = (b1 and 0x80) != 0
+      var payload_len: USize = (b1 and 0x7F).usize()
+
+      // Validate RSV bits
+      if rsv != 0 then
+        return _FrameError(CloseProtocolError)
+      end
+
+      // Validate opcode
+      if not _valid_opcode(opcode) then
+        return _FrameError(CloseProtocolError)
+      end
+
+      // Client frames must be masked
+      if not masked then
+        return _FrameError(CloseProtocolError)
+      end
+
+      // Control frame validation
+      let is_control = (opcode >= 0x08)
+      if is_control then
+        if not fin then
+          return _FrameError(CloseProtocolError)
+        end
+        if payload_len > 125 then
+          return _FrameError(CloseProtocolError)
+        end
+      end
+
+      // Determine header size and extended payload length
+      var header_size: USize = 2
+      if payload_len == 126 then
+        header_size = 4
+        if _buf.size() < header_size then return None end
+        payload_len =
+          (_buf(2)?.usize() << 8) or _buf(3)?.usize()
+      elseif payload_len == 127 then
+        header_size = 10
+        if _buf.size() < header_size then return None end
+        payload_len =
+          (_buf(2)?.usize() << 56) or
+          (_buf(3)?.usize() << 48) or
+          (_buf(4)?.usize() << 40) or
+          (_buf(5)?.usize() << 32) or
+          (_buf(6)?.usize() << 24) or
+          (_buf(7)?.usize() << 16) or
+          (_buf(8)?.usize() << 8) or
+          _buf(9)?.usize()
+      end
+
+      // Mask key (4 bytes, always present since masked is required)
+      let mask_offset = header_size
+      let total_header = header_size + 4
+      if _buf.size() < total_header then return None end
+
+      // Extract mask key bytes individually (U8 val is sendable)
+      let mk0 = _buf(mask_offset)?
+      let mk1 = _buf(mask_offset + 1)?
+      let mk2 = _buf(mask_offset + 2)?
+      let mk3 = _buf(mask_offset + 3)?
+      let mask_key: Array[U8] val =
+        recover val [as U8: mk0; mk1; mk2; mk3] end
+
+      // Check if we have the full payload
+      let frame_size = total_header + payload_len
+      if _buf.size() < frame_size then return None end
+
+      // Extract and unmask payload. Build ref String from bytes, then
+      // clone().iso_array() to get Array[U8] val without a recover
+      // block that accesses _buf.
+      let payload_s = String(payload_len)
+      var i: USize = 0
+      while i < payload_len do
+        let masked_byte = _buf(total_header + i)?
+        let mask_byte = mask_key(i % 4)?
+        payload_s.push(masked_byte xor mask_byte)
+        i = i + 1
+      end
+      let payload: Array[U8] val = payload_s.clone().iso_array()
+
+      // Validate close frame payload
+      if opcode == 0x08 then
+        if payload.size() == 1 then
+          return _FrameError(CloseProtocolError)
+        end
+        // Validate close reason is valid UTF-8
+        if payload.size() > 2 then
+          let reason_s = String(payload.size() - 2)
+          var ri: USize = 2
+          while ri < payload.size() do
+            reason_s.push(payload(ri)?)
+            ri = ri + 1
+          end
+          let reason_bytes: Array[U8] val = reason_s.clone().iso_array()
+          if not _Utf8Validator.is_valid(reason_bytes) then
+            return _FrameError(CloseProtocolError)
+          end
+        end
+      end
+
+      // Compact buffer: remove consumed bytes
+      let new_buf = Array[U8](_buf.size() - frame_size)
+      var j: USize = frame_size
+      while j < _buf.size() do
+        new_buf.push(_buf(j)?)
+        j = j + 1
+      end
+      _buf = new_buf
+
+      _ParsedFrame(fin, opcode, payload)
+    else
+      _Unreachable()
+      _FrameError(CloseInternalError)
+    end
+
+  fun _valid_opcode(opcode: U8): Bool =>
+    """Check if the opcode is a known WebSocket opcode."""
+    match opcode
+    | 0x00 => true // Continuation
+    | 0x01 => true // Text
+    | 0x02 => true // Binary
+    | 0x08 => true // Close
+    | 0x09 => true // Ping
+    | 0x0A => true // Pong
+    else false
+    end
+
+class val _ParsedFrame
+  """A parsed and unmasked WebSocket frame."""
+  let fin: Bool
+  let opcode: U8
+  let payload: Array[U8] val
+
+  new val create(fin': Bool, opcode': U8, payload': Array[U8] val) =>
+    fin = fin'
+    opcode = opcode'
+    payload = payload'
+
+class val _FrameError
+  """A protocol violation detected during frame parsing."""
+  let code: CloseCode
+
+  new val create(code': CloseCode) =>
+    code = code'

--- a/websockets/_handshake_parser.pony
+++ b/websockets/_handshake_parser.pony
@@ -1,0 +1,195 @@
+use crypto = "ssl/crypto"
+use "encode/base64"
+
+class _HandshakeParser
+  """
+  Buffers and parses an HTTP upgrade request for the WebSocket handshake.
+
+  Accumulates incoming data until the full HTTP request is received
+  (delimited by `\r\n\r\n`). Validates WebSocket-specific headers and
+  computes the Sec-WebSocket-Accept key per RFC 6455 Section 4.2.2.
+  """
+  var _buf: Array[U8] ref = Array[U8]
+
+  fun ref apply(
+    data: Array[U8] iso,
+    max_size: USize)
+    : (_HandshakeResult | _HandshakeNeedMore | HandshakeError)
+  =>
+    """
+    Feed incoming data into the buffer and attempt to parse.
+
+    Returns `_HandshakeNeedMore` if the full HTTP request hasn't arrived
+    yet, a `_HandshakeResult` on success, or a `HandshakeError` on
+    failure.
+    """
+    _buf.append(consume data)
+
+    if _buf.size() > max_size then
+      return HandshakeRequestTooLarge
+    end
+
+    match _find_header_end()
+    | None => _HandshakeNeedMore
+    | let pos: USize => _parse_request(pos)
+    end
+
+  fun _find_header_end(): (USize | None) =>
+    """Find the position of \\r\\n\\r\\n in the buffer."""
+    if _buf.size() < 4 then return None end
+    var i: USize = 0
+    let limit = _buf.size() - 3
+    while i < limit do
+      try
+        if (_buf(i)? == '\r') and (_buf(i + 1)? == '\n')
+          and (_buf(i + 2)? == '\r') and (_buf(i + 3)? == '\n')
+        then
+          return i
+        end
+      else
+        _Unreachable()
+      end
+      i = i + 1
+    end
+    None
+
+  fun _parse_request(header_end: USize)
+    : (_HandshakeResult | HandshakeError)
+  =>
+    """Parse the buffered HTTP request up to header_end."""
+    // Build request string from buffer bytes. String.clone() gives iso^
+    // which auto-converts to val.
+    let request_ref = String(header_end)
+    var i: USize = 0
+    while i < header_end do
+      try request_ref.push(_buf(i)?) else _Unreachable() end
+      i = i + 1
+    end
+    let request_str: String val = request_ref.clone()
+
+    // Split into lines
+    let lines = request_str.split_by("\r\n")
+
+    // Parse request line
+    try
+      let request_line = lines(0)?
+      let parts = request_line.split(" ")
+      if parts.size() < 3 then return HandshakeInvalidHTTP end
+      let method = parts(0)?
+      let uri = parts(1)?
+      let version = parts(2)?
+      if method != "GET" then return HandshakeInvalidHTTP end
+      if version != "HTTP/1.1" then return HandshakeInvalidHTTP end
+
+      // Parse headers
+      let headers = recover val
+        let h = Array[(String val, String val)]
+        var j: USize = 1
+        while j < lines.size() do
+          let line = lines(j)?
+          let colon = try line.find(":")? else j = j + 1; continue end
+          // UpgradeRequest.header() depends on names being pre-lowered here.
+          let name: String val = line.substring(0, colon).lower()
+          let value: String val = line.substring(colon + 1).>strip()
+          h.push((name, value))
+          j = j + 1
+        end
+        h
+      end
+
+      // Validate required WebSocket headers
+      var has_upgrade = false
+      var has_connection_upgrade = false
+      var websocket_key: (String val | None) = None
+      var websocket_version: (String val | None) = None
+
+      for (name, value) in headers.values() do
+        if name == "upgrade" then
+          let value_lower: String val = value.lower()
+          if value_lower == "websocket" then
+            has_upgrade = true
+          end
+        elseif name == "connection" then
+          // Connection header may contain multiple comma-separated tokens
+          let tokens: Array[String val] val = value.split(",")
+          for token in tokens.values() do
+            let trimmed: String val = token.clone().>strip()
+            let trimmed_lower: String val = trimmed.lower()
+            if trimmed_lower == "upgrade" then
+              has_connection_upgrade = true
+            end
+          end
+        elseif name == "sec-websocket-version" then
+          websocket_version = value
+        elseif name == "sec-websocket-key" then
+          websocket_key = value
+        end
+      end
+
+      if not has_upgrade then return HandshakeMissingUpgrade end
+      if not has_connection_upgrade then return HandshakeMissingUpgrade end
+
+      match websocket_version
+      | let v: String val =>
+        if v != "13" then return HandshakeWrongVersion end
+      | None => return HandshakeWrongVersion
+      end
+
+      match websocket_key
+      | let key: String val =>
+        let accept_key = _compute_accept_key(key)
+
+        // Extract remaining bytes after \r\n\r\n using String
+        // intermediary: build ref String, clone to iso, iso_array to val
+        let remaining_start = header_end + 4
+        let remaining_s = String(_buf.size() - remaining_start)
+        var k: USize = remaining_start
+        while k < _buf.size() do
+          try remaining_s.push(_buf(k)?) else _Unreachable() end
+          k = k + 1
+        end
+        let remaining: Array[U8] val = remaining_s.clone().iso_array()
+
+        let request = UpgradeRequest(uri, headers)
+        _HandshakeResult(request, accept_key, remaining)
+      | None => HandshakeMissingKey
+      end
+    else
+      HandshakeInvalidHTTP
+    end
+
+  fun _compute_accept_key(key: String val): String val =>
+    """
+    Compute the Sec-WebSocket-Accept value.
+
+    Concatenates the client key with the WebSocket GUID, takes the SHA-1
+    hash, and Base64-encodes the result.
+    """
+    let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+    let sha = crypto.Digest.sha1()
+    try
+      sha.>append(key)?.append(magic)?
+    else
+      _Unreachable()
+    end
+    let hash = sha.final()
+    let encoded: String val = Base64.encode(hash)
+    encoded
+
+class val _HandshakeResult
+  """A successfully parsed WebSocket upgrade request."""
+  let request: UpgradeRequest val
+  let accept_key: String val
+  let remaining: Array[U8] val
+
+  new val create(
+    request': UpgradeRequest val,
+    accept_key': String val,
+    remaining': Array[U8] val)
+  =>
+    request = request'
+    accept_key = accept_key'
+    remaining = remaining'
+
+primitive _HandshakeNeedMore
+  """More data is needed to complete the HTTP upgrade request."""

--- a/websockets/_mort.pony
+++ b/websockets/_mort.pony
@@ -1,0 +1,19 @@
+use @exit[None](status: I32)
+use @fprintf[I32](stream: Pointer[None] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[None]]()
+
+primitive _Unreachable
+  """
+  To be used in places that the compiler can't prove is unreachable but we are
+  certain is unreachable and if we reach it, we'd be silently hiding a bug.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("The unreachable was reached in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/websockets/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)

--- a/websockets/_test.pony
+++ b/websockets/_test.pony
@@ -1,8 +1,77 @@
 use "pony_test"
+use "pony_check"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 
   fun tag tests(test: PonyTest) =>
-    None
+    // UTF-8 validator
+    test(_TestUtf8ValidAscii)
+    test(_TestUtf8ValidEmpty)
+    test(_TestUtf8ValidTwoByte)
+    test(_TestUtf8ValidThreeByte)
+    test(_TestUtf8ValidFourByte)
+    test(_TestUtf8InvalidTruncated)
+    test(_TestUtf8InvalidOverlong)
+    test(_TestUtf8InvalidSurrogate)
+    test(_TestUtf8InvalidAboveMax)
+    test(_TestUtf8InvalidContinuationFirst)
+    test(Property1UnitTest[String](_TestUtf8PropertyValidStrings))
+    test(Property1UnitTest[U8](_TestUtf8PropertyInvalidByte))
+
+    // Frame encoder
+    test(_TestFrameEncoderText)
+    test(_TestFrameEncoderBinary)
+    test(_TestFrameEncoderCloseWithCode)
+    test(_TestFrameEncoderCloseEmpty)
+    test(_TestFrameEncoderPong)
+    test(_TestFrameEncoderLength16Bit)
+    test(_TestFrameEncoderLength64Bit)
+    test(Property1UnitTest[USize](_TestFrameEncoderPropertyRoundtrip))
+
+    // Frame parser
+    test(_TestFrameParserText)
+    test(_TestFrameParserBinary)
+    test(_TestFrameParserPing)
+    test(_TestFrameParserPong)
+    test(_TestFrameParserCloseWithCode)
+    test(_TestFrameParserCloseEmpty)
+    test(_TestFrameParserCloseOneByte)
+    test(_TestFrameParserCloseInvalidUtf8Reason)
+    test(_TestFrameParserCloseValidUtf8Reason)
+    test(_TestFrameParserLength16Bit)
+    test(_TestFrameParserLength64Bit)
+    test(_TestFrameParserUnmasked)
+    test(_TestFrameParserNonZeroRsv)
+    test(_TestFrameParserFragmentedControl)
+    test(_TestFrameParserControlTooLarge)
+    test(_TestFrameParserUnknownOpcode)
+    test(_TestFrameParserIncremental)
+    test(_TestFrameParserMultipleFrames)
+    test(Property1UnitTest[USize](_TestFrameParserPropertyRandom))
+
+    // Handshake parser
+    test(_TestHandshakeValid)
+    test(_TestHandshakeRemainingBytes)
+    test(_TestHandshakeTooLarge)
+    test(_TestHandshakeInvalidMethod)
+    test(_TestHandshakeMissingUpgrade)
+    test(_TestHandshakeWrongVersion)
+    test(_TestHandshakeMissingKey)
+    test(_TestHandshakeCaseInsensitive)
+    test(_TestHandshakeIncremental)
+    test(_TestHandshakeRfc6455AcceptKey)
+    test(_TestHandshakeConnectionMultiToken)
+    test(Property1UnitTest[String](_TestHandshakePropertyValidRequests))
+
+    // Fragment reassembler
+    test(_TestReassemblerSingleText)
+    test(_TestReassemblerSingleBinary)
+    test(_TestReassemblerMultiFragment)
+    test(_TestReassemblerInterleavedData)
+    test(_TestReassemblerMaxSize)
+    test(_TestReassemblerInvalidUtf8)
+    test(_TestReassemblerValidUtf8)
+    test(_TestReassemblerContinuationWithoutStart)
+    test(Property1UnitTest[USize](_TestReassemblerPropertyRoundtrip))

--- a/websockets/_test_fragment_reassembler.pony
+++ b/websockets/_test_fragment_reassembler.pony
@@ -1,0 +1,222 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _TestReassemblerSingleText is UnitTest
+  """Single unfragmented text message is delivered immediately."""
+  fun name(): String => "reassembler/single_text"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+    let payload: Array[U8] val = "Hello".array()
+    match reassembler.frame(true, 0x01, payload, 1_048_576)
+    | let msg: _CompleteMessage =>
+      h.assert_true(msg.is_text)
+      h.assert_eq[USize](5, msg.data.size())
+    | _FragmentContinue => h.fail("expected complete message")
+    | let err: _ReassemblyError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestReassemblerSingleBinary is UnitTest
+  """Single unfragmented binary message is delivered immediately."""
+  fun name(): String => "reassembler/single_binary"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+    let payload: Array[U8] val = recover val [as U8: 0x01; 0x02] end
+    match reassembler.frame(true, 0x02, payload, 1_048_576)
+    | let msg: _CompleteMessage =>
+      h.assert_false(msg.is_text)
+      h.assert_eq[USize](2, msg.data.size())
+    | _FragmentContinue => h.fail("expected complete message")
+    | let err: _ReassemblyError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestReassemblerMultiFragment is UnitTest
+  """Multi-fragment text message delivers on final frame."""
+  fun name(): String => "reassembler/multi_fragment"
+
+  fun apply(h: TestHelper) ? =>
+    let reassembler = _FragmentReassembler
+
+    // First fragment: text, FIN=0
+    let frag1: Array[U8] val = "Hel".array()
+    match reassembler.frame(false, 0x01, frag1, 1_048_576)
+    | _FragmentContinue => None // expected
+    | let _: _CompleteMessage => h.fail("too early")
+    | let err: _ReassemblyError => h.fail("unexpected error")
+    end
+
+    // Continuation: FIN=0
+    let frag2: Array[U8] val = "lo ".array()
+    match reassembler.frame(false, 0x00, frag2, 1_048_576)
+    | _FragmentContinue => None // expected
+    | let _: _CompleteMessage => h.fail("too early")
+    | let err: _ReassemblyError => h.fail("unexpected error")
+    end
+
+    // Final continuation: FIN=1
+    let frag3: Array[U8] val = "World".array()
+    match reassembler.frame(true, 0x00, frag3, 1_048_576)
+    | let msg: _CompleteMessage =>
+      h.assert_true(msg.is_text)
+      h.assert_eq[USize](11, msg.data.size())
+      // Verify "Hello World"
+      h.assert_eq[U8]('H', msg.data(0)?)
+      h.assert_eq[U8]('d', msg.data(10)?)
+    | _FragmentContinue => h.fail("expected complete after final fragment")
+    | let err: _ReassemblyError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestReassemblerInterleavedData is UnitTest
+  """Interleaved data frame during fragmentation is rejected."""
+  fun name(): String => "reassembler/interleaved_data"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+
+    // Start a text message
+    let frag1: Array[U8] val = "Hello".array()
+    match reassembler.frame(false, 0x01, frag1, 1_048_576)
+    | _FragmentContinue => None
+    else h.fail("expected continue")
+    end
+
+    // Attempt to start a new text message (interleaved)
+    let frag2: Array[U8] val = "World".array()
+    match reassembler.frame(true, 0x01, frag2, 1_048_576)
+    | let err: _ReassemblyError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    | _FragmentContinue => h.fail("expected error")
+    | let _: _CompleteMessage => h.fail("expected error")
+    end
+
+class \nodoc\ iso _TestReassemblerMaxSize is UnitTest
+  """Accumulated size exceeding max_message_size is rejected."""
+  fun name(): String => "reassembler/max_size"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](100)
+      var i: USize = 0
+      while i < 100 do a.push(0x41); i = i + 1 end
+      a
+    end
+    match reassembler.frame(true, 0x02, payload, 50) // max=50
+    | let err: _ReassemblyError =>
+      h.assert_is[CloseCode](CloseMessageTooBig, err.code)
+    | _FragmentContinue => h.fail("expected error")
+    | let _: _CompleteMessage => h.fail("expected error")
+    end
+
+class \nodoc\ iso _TestReassemblerInvalidUtf8 is UnitTest
+  """Text message with invalid UTF-8 is rejected."""
+  fun name(): String => "reassembler/invalid_utf8"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+    let payload: Array[U8] val = recover val [as U8: 0xFF; 0xFE] end
+    match reassembler.frame(true, 0x01, payload, 1_048_576)
+    | let err: _ReassemblyError =>
+      h.assert_is[CloseCode](CloseInvalidPayload, err.code)
+    | _FragmentContinue => h.fail("expected error")
+    | let _: _CompleteMessage => h.fail("expected error")
+    end
+
+class \nodoc\ iso _TestReassemblerValidUtf8 is UnitTest
+  """Text message with valid UTF-8 succeeds."""
+  fun name(): String => "reassembler/valid_utf8"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+    // Valid UTF-8: "café" = 63 61 66 C3 A9
+    let payload: Array[U8] val =
+      recover val [as U8: 0x63; 0x61; 0x66; 0xC3; 0xA9] end
+    match reassembler.frame(true, 0x01, payload, 1_048_576)
+    | let msg: _CompleteMessage =>
+      h.assert_true(msg.is_text)
+      h.assert_eq[USize](5, msg.data.size())
+    | _FragmentContinue => h.fail("expected complete message")
+    | let err: _ReassemblyError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestReassemblerContinuationWithoutStart is UnitTest
+  """Continuation frame without a preceding start frame is rejected."""
+  fun name(): String => "reassembler/continuation_without_start"
+
+  fun apply(h: TestHelper) =>
+    let reassembler = _FragmentReassembler
+    let payload: Array[U8] val = "data".array()
+    match reassembler.frame(true, 0x00, payload, 1_048_576)
+    | let err: _ReassemblyError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    | _FragmentContinue => h.fail("expected error")
+    | let _: _CompleteMessage => h.fail("expected error")
+    end
+
+class \nodoc\ iso _TestReassemblerPropertyRoundtrip is Property1[USize]
+  """Random payloads split into fragments reassemble to original."""
+  fun name(): String => "reassembler/property_roundtrip"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(where min = 1, max = 500)
+
+  fun property(total_size: USize, h: PropertyHelper) ? =>
+    // Build a payload
+    let full_payload = recover val
+      let a = Array[U8](total_size)
+      var i: USize = 0
+      while i < total_size do
+        a.push((i % 256).u8())
+        i = i + 1
+      end
+      a
+    end
+
+    // Split into 3 fragments
+    let split1 = total_size / 3
+    let split2 = (total_size * 2) / 3
+
+    let frag1 = recover val
+      let a = Array[U8](split1)
+      var i: USize = 0
+      while i < split1 do a.push(full_payload(i)?); i = i + 1 end
+      a
+    end
+    let frag2 = recover val
+      let a = Array[U8](split2 - split1)
+      var i: USize = split1
+      while i < split2 do a.push(full_payload(i)?); i = i + 1 end
+      a
+    end
+    let frag3 = recover val
+      let a = Array[U8](total_size - split2)
+      var i: USize = split2
+      while i < total_size do a.push(full_payload(i)?); i = i + 1 end
+      a
+    end
+
+    let reassembler = _FragmentReassembler
+    match reassembler.frame(false, 0x02, frag1, total_size + 1)
+    | _FragmentContinue => None
+    else h.fail("expected continue for frag1")
+    end
+    match reassembler.frame(false, 0x00, frag2, total_size + 1)
+    | _FragmentContinue => None
+    else h.fail("expected continue for frag2")
+    end
+    match reassembler.frame(true, 0x00, frag3, total_size + 1)
+    | let msg: _CompleteMessage =>
+      h.assert_false(msg.is_text)
+      h.assert_eq[USize](total_size, msg.data.size())
+      // Verify every byte
+      var i: USize = 0
+      while i < total_size do
+        h.assert_eq[U8](full_payload(i)?, msg.data(i)?)
+        i = i + 1
+      end
+    | _FragmentContinue =>
+      h.fail("expected complete after final fragment")
+    | let err: _ReassemblyError =>
+      h.fail("unexpected error")
+    end

--- a/websockets/_test_frame_encoder.pony
+++ b/websockets/_test_frame_encoder.pony
@@ -1,0 +1,226 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _TestFrameEncoderText is UnitTest
+  """Text frame: FIN=1, opcode=0x1, MASK=0, correct payload."""
+  fun name(): String => "frame_encoder/text"
+
+  fun apply(h: TestHelper) ? =>
+    let frame = _FrameEncoder.text("Hello")
+    // First byte: FIN(0x80) | opcode(0x01) = 0x81
+    h.assert_eq[U8](0x81, frame(0)?)
+    // Second byte: MASK=0, length=5
+    h.assert_eq[U8](5, frame(1)?)
+    // Payload
+    h.assert_eq[U8]('H', frame(2)?)
+    h.assert_eq[U8]('e', frame(3)?)
+    h.assert_eq[U8]('l', frame(4)?)
+    h.assert_eq[U8]('l', frame(5)?)
+    h.assert_eq[U8]('o', frame(6)?)
+    h.assert_eq[USize](7, frame.size())
+
+class \nodoc\ iso _TestFrameEncoderBinary is UnitTest
+  """Binary frame: FIN=1, opcode=0x2, correct payload."""
+  fun name(): String => "frame_encoder/binary"
+
+  fun apply(h: TestHelper) ? =>
+    let data: Array[U8] val = recover val [as U8: 0x01; 0x02; 0x03] end
+    let frame = _FrameEncoder.binary(data)
+    h.assert_eq[U8](0x82, frame(0)?)
+    h.assert_eq[U8](3, frame(1)?)
+    h.assert_eq[U8](0x01, frame(2)?)
+    h.assert_eq[U8](0x02, frame(3)?)
+    h.assert_eq[U8](0x03, frame(4)?)
+
+class \nodoc\ iso _TestFrameEncoderCloseWithCode is UnitTest
+  """Close frame with status code and reason."""
+  fun name(): String => "frame_encoder/close_with_code"
+
+  fun apply(h: TestHelper) ? =>
+    let frame = _FrameEncoder.close(CloseNormal, "bye")
+    // FIN=1, opcode=0x8
+    h.assert_eq[U8](0x88, frame(0)?)
+    // Length: 2 (status) + 3 (reason) = 5
+    h.assert_eq[U8](5, frame(1)?)
+    // Status code 1000 big-endian
+    h.assert_eq[U8](0x03, frame(2)?)
+    h.assert_eq[U8](0xE8, frame(3)?)
+    // Reason
+    h.assert_eq[U8]('b', frame(4)?)
+    h.assert_eq[U8]('y', frame(5)?)
+    h.assert_eq[U8]('e', frame(6)?)
+
+class \nodoc\ iso _TestFrameEncoderCloseEmpty is UnitTest
+  """Close frame with no payload."""
+  fun name(): String => "frame_encoder/close_empty"
+
+  fun apply(h: TestHelper) ? =>
+    let frame = _FrameEncoder.close_empty()
+    h.assert_eq[U8](0x88, frame(0)?)
+    h.assert_eq[U8](0, frame(1)?)
+    h.assert_eq[USize](2, frame.size())
+
+class \nodoc\ iso _TestFrameEncoderPong is UnitTest
+  """Pong frame echoes payload."""
+  fun name(): String => "frame_encoder/pong"
+
+  fun apply(h: TestHelper) ? =>
+    let payload: Array[U8] val = recover val [as U8: 0xAA; 0xBB] end
+    let frame = _FrameEncoder.pong(payload)
+    // FIN=1, opcode=0xA
+    h.assert_eq[U8](0x8A, frame(0)?)
+    h.assert_eq[U8](2, frame(1)?)
+    h.assert_eq[U8](0xAA, frame(2)?)
+    h.assert_eq[U8](0xBB, frame(3)?)
+
+class \nodoc\ iso _TestFrameEncoderLength16Bit is UnitTest
+  """Payload 126-65535 bytes uses 16-bit extended length."""
+  fun name(): String => "frame_encoder/length_16bit"
+
+  fun apply(h: TestHelper) ? =>
+    // Create 200-byte payload
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](200)
+      var i: USize = 0
+      while i < 200 do
+        a.push(0x41)
+        i = i + 1
+      end
+      a
+    end
+    let frame = _FrameEncoder.binary(payload)
+    h.assert_eq[U8](0x82, frame(0)?)
+    // Length indicator: 126
+    h.assert_eq[U8](126, frame(1)?)
+    // 16-bit big-endian length: 200 = 0x00C8
+    h.assert_eq[U8](0x00, frame(2)?)
+    h.assert_eq[U8](0xC8, frame(3)?)
+    // Total frame size: 2 + 2 (extended length) + 200 = 204
+    h.assert_eq[USize](204, frame.size())
+
+class \nodoc\ iso _TestFrameEncoderLength64Bit is UnitTest
+  """Payload > 65535 bytes uses 64-bit extended length."""
+  fun name(): String => "frame_encoder/length_64bit"
+
+  fun apply(h: TestHelper) ? =>
+    // Create 65536-byte payload
+    let size: USize = 65536
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](size)
+      var i: USize = 0
+      while i < size do
+        a.push(0x42)
+        i = i + 1
+      end
+      a
+    end
+    let frame = _FrameEncoder.binary(payload)
+    h.assert_eq[U8](0x82, frame(0)?)
+    // Length indicator: 127
+    h.assert_eq[U8](127, frame(1)?)
+    // 64-bit big-endian length: 65536 = 0x0000000000010000
+    h.assert_eq[U8](0x00, frame(2)?)
+    h.assert_eq[U8](0x00, frame(3)?)
+    h.assert_eq[U8](0x00, frame(4)?)
+    h.assert_eq[U8](0x00, frame(5)?)
+    h.assert_eq[U8](0x00, frame(6)?)
+    h.assert_eq[U8](0x01, frame(7)?)
+    h.assert_eq[U8](0x00, frame(8)?)
+    h.assert_eq[U8](0x00, frame(9)?)
+    // Total frame size: 2 + 8 (extended length) + 65536 = 65546
+    h.assert_eq[USize](65546, frame.size())
+
+class \nodoc\ iso _TestFrameEncoderPropertyRoundtrip is Property1[USize]
+  """Encoded frames can be parsed back through the frame parser."""
+  fun name(): String => "frame_encoder/property_roundtrip"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(where min = 0, max = 300)
+
+  fun property(payload_size: USize, h: PropertyHelper) ? =>
+    // Build a payload of the given size
+    let payload_s = String(payload_size)
+    var i: USize = 0
+    while i < payload_size do
+      payload_s.push('A')
+      i = i + 1
+    end
+    let payload: Array[U8] val = payload_s.clone().iso_array()
+
+    // Encode as binary frame (server-to-client, unmasked)
+    let frame = _FrameEncoder.binary(payload)
+
+    // To parse through _FrameParser, we need to mask the frame
+    // (client-to-server). Build a masked version.
+    let mask_key: Array[U8] val = recover val [as U8: 0x37; 0xFA; 0x21; 0x3D] end
+    let masked = _mask_frame(frame, mask_key)?
+
+    // Parse
+    let parser = _FrameParser
+    match parser.parse(masked)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      let parsed = frames(0)?
+      h.assert_true(parsed.fin)
+      h.assert_eq[U8](0x02, parsed.opcode)
+      h.assert_eq[USize](payload_size, parsed.payload.size())
+      // Verify payload bytes match
+      var j: USize = 0
+      while j < payload_size do
+        h.assert_eq[U8](payload(j)?, parsed.payload(j)?)
+        j = j + 1
+      end
+    | let err: _FrameError =>
+      h.fail("Frame parser returned error")
+    end
+
+  fun _mask_frame(
+    frame: Array[U8] val,
+    mask_key: Array[U8] val)
+    : Array[U8] val ?
+  =>
+    """
+    Convert an unmasked server frame to a masked client frame for
+    testing. Sets the MASK bit and inserts the mask key, then XORs
+    the payload.
+    """
+    // Read the original header
+    let b0 = frame(0)?
+    let b1 = frame(1)?
+    let orig_len_byte = b1 and 0x7F
+
+    // Determine header size and payload offset
+    var header_size: USize = 2
+    if orig_len_byte == 126 then header_size = 4
+    elseif orig_len_byte == 127 then header_size = 10
+    end
+    let payload_offset = header_size
+    let payload_size = frame.size() - payload_offset
+
+    // Build masked frame
+    let result = recover iso
+      let r = Array[U8](header_size + 4 + payload_size)
+      // Copy first byte unchanged
+      r.push(b0)
+      // Set MASK bit on second byte
+      r.push(b1 or 0x80)
+      // Copy extended length bytes if any
+      var i: USize = 2
+      while i < header_size do
+        r.push(frame(i)?)
+        i = i + 1
+      end
+      // Insert mask key
+      r.push(mask_key(0)?)
+      r.push(mask_key(1)?)
+      r.push(mask_key(2)?)
+      r.push(mask_key(3)?)
+      // Mask payload
+      var j: USize = 0
+      while j < payload_size do
+        r.push(frame(payload_offset + j)? xor mask_key(j % 4)?)
+        j = j + 1
+      end
+      r
+    end
+    consume result

--- a/websockets/_test_frame_parser.pony
+++ b/websockets/_test_frame_parser.pony
@@ -1,0 +1,460 @@
+use "pony_test"
+use "pony_check"
+
+primitive \nodoc\ _TestFrameHelper
+  """Helpers for building masked WebSocket frames for parser testing."""
+
+  fun masked_frame(
+    fin: Bool,
+    opcode: U8,
+    payload: Array[U8] val,
+    mask_key: Array[U8] val = recover val [as U8: 0x37; 0xFA; 0x21; 0x3D] end)
+    : Array[U8] val
+  =>
+    """Build a masked client frame from components."""
+    let payload_size = payload.size()
+
+    recover val
+      let frame = Array[U8]
+      // First byte
+      let first: U8 = if fin then 0x80 or opcode else opcode end
+      frame.push(first)
+
+      // Second byte: MASK=1 + length
+      if payload_size <= 125 then
+        frame.push(0x80 or payload_size.u8())
+      elseif payload_size <= 65535 then
+        frame.push(0x80 or 126)
+        frame.>push((payload_size >> 8).u8())
+          .push((payload_size and 0xFF).u8())
+      else
+        frame.push(0x80 or 127)
+        frame.>push((payload_size >> 56).u8())
+          .>push(((payload_size >> 48) and 0xFF).u8())
+          .>push(((payload_size >> 40) and 0xFF).u8())
+          .>push(((payload_size >> 32) and 0xFF).u8())
+          .>push(((payload_size >> 24) and 0xFF).u8())
+          .>push(((payload_size >> 16) and 0xFF).u8())
+          .>push(((payload_size >> 8) and 0xFF).u8())
+          .push((payload_size and 0xFF).u8())
+      end
+
+      // Mask key
+      try
+        frame.>push(mask_key(0)?)
+          .>push(mask_key(1)?)
+          .>push(mask_key(2)?)
+          .push(mask_key(3)?)
+
+        // Masked payload
+        var i: USize = 0
+        while i < payload_size do
+          frame.push(payload(i)? xor mask_key(i % 4)?)
+          i = i + 1
+        end
+      else
+        _Unreachable()
+      end
+      frame
+    end
+
+  fun unmasked_frame(
+    fin: Bool,
+    opcode: U8,
+    payload: Array[U8] val)
+    : Array[U8] val
+  =>
+    """Build an unmasked frame (for testing rejection)."""
+    let payload_size = payload.size()
+
+    recover val
+      let frame = Array[U8]
+      let first: U8 = if fin then 0x80 or opcode else opcode end
+      frame.push(first)
+
+      if payload_size <= 125 then
+        frame.push(payload_size.u8())
+      elseif payload_size <= 65535 then
+        frame.push(126)
+        frame.>push((payload_size >> 8).u8())
+          .push((payload_size and 0xFF).u8())
+      else
+        frame.push(127)
+        frame.>push((payload_size >> 56).u8())
+          .>push(((payload_size >> 48) and 0xFF).u8())
+          .>push(((payload_size >> 40) and 0xFF).u8())
+          .>push(((payload_size >> 32) and 0xFF).u8())
+          .>push(((payload_size >> 24) and 0xFF).u8())
+          .>push(((payload_size >> 16) and 0xFF).u8())
+          .>push(((payload_size >> 8) and 0xFF).u8())
+          .push((payload_size and 0xFF).u8())
+      end
+
+      frame.append(payload)
+      frame
+    end
+
+class \nodoc\ iso _TestFrameParserText is UnitTest
+  """Single masked text frame is parsed correctly."""
+  fun name(): String => "frame_parser/text"
+
+  fun apply(h: TestHelper) ? =>
+    let frame = _TestFrameHelper.masked_frame(
+      true, 0x01, "Hello".array())
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_true(frames(0)?.fin)
+      h.assert_eq[U8](0x01, frames(0)?.opcode)
+      h.assert_eq[USize](5, frames(0)?.payload.size())
+      h.assert_eq[U8]('H', frames(0)?.payload(0)?)
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserBinary is UnitTest
+  """Single masked binary frame is parsed correctly."""
+  fun name(): String => "frame_parser/binary"
+
+  fun apply(h: TestHelper) ? =>
+    let payload: Array[U8] val = recover val [as U8: 0x01; 0x02; 0x03] end
+    let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x02, frames(0)?.opcode)
+      h.assert_eq[U8](0x01, frames(0)?.payload(0)?)
+      h.assert_eq[U8](0x02, frames(0)?.payload(1)?)
+      h.assert_eq[U8](0x03, frames(0)?.payload(2)?)
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserPing is UnitTest
+  """Ping frame with payload ≤ 125 bytes."""
+  fun name(): String => "frame_parser/ping"
+
+  fun apply(h: TestHelper) ? =>
+    let payload: Array[U8] val = recover val [as U8: 0xAA; 0xBB] end
+    let frame = _TestFrameHelper.masked_frame(true, 0x09, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x09, frames(0)?.opcode)
+      h.assert_eq[USize](2, frames(0)?.payload.size())
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserPong is UnitTest
+  """Pong frame."""
+  fun name(): String => "frame_parser/pong"
+
+  fun apply(h: TestHelper) ? =>
+    let frame = _TestFrameHelper.masked_frame(
+      true, 0x0A, recover val Array[U8] end)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x0A, frames(0)?.opcode)
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserCloseWithCode is UnitTest
+  """Close frame with status code and reason."""
+  fun name(): String => "frame_parser/close_with_code"
+
+  fun apply(h: TestHelper) ? =>
+    // Close frame payload: 2-byte status (1000) + "bye"
+    let payload: Array[U8] val =
+      recover val [as U8: 0x03; 0xE8; 'b'; 'y'; 'e'] end
+    let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x08, frames(0)?.opcode)
+      h.assert_eq[USize](5, frames(0)?.payload.size())
+      // Status code 1000 big-endian
+      h.assert_eq[U8](0x03, frames(0)?.payload(0)?)
+      h.assert_eq[U8](0xE8, frames(0)?.payload(1)?)
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserCloseEmpty is UnitTest
+  """Close frame with no payload is valid."""
+  fun name(): String => "frame_parser/close_empty"
+
+  fun apply(h: TestHelper) ? =>
+    let frame = _TestFrameHelper.masked_frame(
+      true, 0x08, recover val Array[U8] end)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x08, frames(0)?.opcode)
+      h.assert_eq[USize](0, frames(0)?.payload.size())
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserCloseOneByte is UnitTest
+  """Close frame with 1-byte payload is a protocol error."""
+  fun name(): String => "frame_parser/close_one_byte"
+
+  fun apply(h: TestHelper) =>
+    let payload: Array[U8] val = recover val [as U8: 0x03] end
+    let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for 1-byte close payload")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserCloseInvalidUtf8Reason is UnitTest
+  """Close frame with invalid UTF-8 in reason is a protocol error."""
+  fun name(): String => "frame_parser/close_invalid_utf8_reason"
+
+  fun apply(h: TestHelper) =>
+    // Status 1000 + invalid UTF-8 (0xFF)
+    let payload: Array[U8] val =
+      recover val [as U8: 0x03; 0xE8; 0xFF] end
+    let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for invalid UTF-8 in close reason")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserCloseValidUtf8Reason is UnitTest
+  """Close frame with valid UTF-8 in reason is accepted."""
+  fun name(): String => "frame_parser/close_valid_utf8_reason"
+
+  fun apply(h: TestHelper) ? =>
+    // Status 1000 + valid UTF-8 "OK"
+    let payload: Array[U8] val =
+      recover val [as U8: 0x03; 0xE8; 'O'; 'K'] end
+    let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x08, frames(0)?.opcode)
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserLength16Bit is UnitTest
+  """16-bit extended payload length (126-65535 bytes)."""
+  fun name(): String => "frame_parser/length_16bit"
+
+  fun apply(h: TestHelper) ? =>
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](200)
+      var i: USize = 0
+      while i < 200 do a.push(0x41); i = i + 1 end
+      a
+    end
+    let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[USize](200, frames(0)?.payload.size())
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserLength64Bit is UnitTest
+  """64-bit extended payload length (> 65535 bytes)."""
+  fun name(): String => "frame_parser/length_64bit"
+
+  fun apply(h: TestHelper) ? =>
+    let size: USize = 65536
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](size)
+      var i: USize = 0
+      while i < size do a.push(0x42); i = i + 1 end
+      a
+    end
+    let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[USize](size, frames(0)?.payload.size())
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserUnmasked is UnitTest
+  """Unmasked client frame is rejected."""
+  fun name(): String => "frame_parser/unmasked_rejected"
+
+  fun apply(h: TestHelper) =>
+    let frame = _TestFrameHelper.unmasked_frame(
+      true, 0x01, "Hello".array())
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for unmasked frame")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserNonZeroRsv is UnitTest
+  """Non-zero RSV bits are rejected."""
+  fun name(): String => "frame_parser/non_zero_rsv"
+
+  fun apply(h: TestHelper) =>
+    // Build frame with RSV1 set (0x40)
+    let raw = recover val
+      let f = Array[U8]
+      f.push(0x80 or 0x40 or 0x01) // FIN + RSV1 + text
+      f.push(0x80 or 0x00) // MASK + 0 length
+      f.>push(0x00).>push(0x00).>push(0x00).push(0x00) // mask key
+      f
+    end
+    let parser = _FrameParser
+    match parser.parse(raw)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for RSV bits")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserFragmentedControl is UnitTest
+  """Fragmented control frame (FIN=0) is rejected."""
+  fun name(): String => "frame_parser/fragmented_control"
+
+  fun apply(h: TestHelper) =>
+    let frame = _TestFrameHelper.masked_frame(
+      false, 0x09, recover val Array[U8] end)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for fragmented control frame")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserControlTooLarge is UnitTest
+  """Control frame with payload > 125 bytes is rejected."""
+  fun name(): String => "frame_parser/control_too_large"
+
+  fun apply(h: TestHelper) =>
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](126)
+      var i: USize = 0
+      while i < 126 do a.push(0x00); i = i + 1 end
+      a
+    end
+    let frame = _TestFrameHelper.masked_frame(true, 0x09, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for oversized control frame")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserUnknownOpcode is UnitTest
+  """Unknown opcode is rejected."""
+  fun name(): String => "frame_parser/unknown_opcode"
+
+  fun apply(h: TestHelper) =>
+    let frame = _TestFrameHelper.masked_frame(
+      true, 0x03, recover val Array[U8] end)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.fail("expected error for unknown opcode")
+    | let err: _FrameError =>
+      h.assert_is[CloseCode](CloseProtocolError, err.code)
+    end
+
+class \nodoc\ iso _TestFrameParserIncremental is UnitTest
+  """Byte-by-byte delivery assembles correct frame."""
+  fun name(): String => "frame_parser/incremental"
+
+  fun apply(h: TestHelper) ? =>
+    let full_frame = _TestFrameHelper.masked_frame(
+      true, 0x01, "Hi".array())
+    let parser = _FrameParser
+
+    // Feed one byte at a time
+    var i: USize = 0
+    while i < (full_frame.size() - 1) do
+      let byte: Array[U8] val = recover val [as U8: full_frame(i)?] end
+      match parser.parse(byte)
+      | let frames: Array[_ParsedFrame val] val =>
+        h.assert_eq[USize](0, frames.size())
+      | let err: _FrameError => h.fail("unexpected error at byte " +
+          i.string())
+      end
+      i = i + 1
+    end
+
+    // Feed last byte — should complete the frame
+    let last: Array[U8] val = recover val [as U8: full_frame(i)?] end
+    match parser.parse(last)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x01, frames(0)?.opcode)
+      h.assert_eq[U8]('H', frames(0)?.payload(0)?)
+      h.assert_eq[U8]('i', frames(0)?.payload(1)?)
+    | let err: _FrameError => h.fail("unexpected error on last byte")
+    end
+
+class \nodoc\ iso _TestFrameParserMultipleFrames is UnitTest
+  """Multiple frames in one buffer are all parsed."""
+  fun name(): String => "frame_parser/multiple_frames"
+
+  fun apply(h: TestHelper) ? =>
+    let frame1 = _TestFrameHelper.masked_frame(
+      true, 0x01, "Hi".array())
+    let frame2 = _TestFrameHelper.masked_frame(
+      true, 0x02, recover val [as U8: 0x01] end)
+
+    // Concatenate both frames
+    let combined: Array[U8] val = recover val
+      let c = Array[U8](frame1.size() + frame2.size())
+      for b in frame1.values() do c.push(b) end
+      for b in frame2.values() do c.push(b) end
+      c
+    end
+
+    let parser = _FrameParser
+    match parser.parse(combined)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](2, frames.size())
+      h.assert_eq[U8](0x01, frames(0)?.opcode)
+      h.assert_eq[U8](0x02, frames(1)?.opcode)
+    | let err: _FrameError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestFrameParserPropertyRandom is Property1[USize]
+  """Random valid masked frames parse successfully."""
+  fun name(): String => "frame_parser/property_random_frames"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(where min = 0, max = 200)
+
+  fun property(payload_size: USize, h: PropertyHelper) ? =>
+    let payload: Array[U8] val = recover val
+      let a = Array[U8](payload_size)
+      var i: USize = 0
+      while i < payload_size do a.push((i % 256).u8()); i = i + 1 end
+      a
+    end
+    let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
+    let parser = _FrameParser
+    match parser.parse(frame)
+    | let frames: Array[_ParsedFrame val] val =>
+      h.assert_eq[USize](1, frames.size())
+      h.assert_eq[U8](0x02, frames(0)?.opcode)
+      h.assert_eq[USize](payload_size, frames(0)?.payload.size())
+    | let err: _FrameError =>
+      h.fail("unexpected error for size " + payload_size.string())
+    end

--- a/websockets/_test_handshake_parser.pony
+++ b/websockets/_test_handshake_parser.pony
@@ -1,0 +1,325 @@
+use "pony_test"
+use "pony_check"
+use "encode/base64"
+use crypto = "ssl/crypto"
+
+primitive \nodoc\ _TestHandshakeHelper
+  """Helpers for building HTTP upgrade requests."""
+
+  fun valid_request(
+    uri: String val = "/",
+    key: String val = "dGhlIHNhbXBsZSBub25jZQ==",
+    extra_headers: String val = "")
+    : Array[U8] iso^
+  =>
+    """Build a valid HTTP upgrade request."""
+    let s = String(512)
+      .>append("GET ")
+      .>append(uri)
+      .>append(" HTTP/1.1\r\n")
+      .>append("Host: localhost\r\n")
+      .>append("Upgrade: websocket\r\n")
+      .>append("Connection: Upgrade\r\n")
+      .>append("Sec-WebSocket-Key: ")
+      .>append(key)
+      .>append("\r\n")
+      .>append("Sec-WebSocket-Version: 13\r\n")
+      .>append(extra_headers)
+      .>append("\r\n")
+    s.clone().iso_array()
+
+  fun compute_accept_key(key: String val): String val =>
+    """Compute expected Sec-WebSocket-Accept value."""
+    let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+    let sha = crypto.Digest.sha1()
+    try sha.>append(key)?.append(magic)? else _Unreachable() end
+    let hash = sha.final()
+    Base64.encode(hash)
+
+class \nodoc\ iso _TestHandshakeValid is UnitTest
+  """Valid complete upgrade request produces correct result."""
+  fun name(): String => "handshake/valid_complete"
+
+  fun apply(h: TestHelper) =>
+    let parser = _HandshakeParser
+    let data = _TestHandshakeHelper.valid_request()
+    match parser(consume data, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[String]("/", result.request.uri)
+      let expected_key =
+        _TestHandshakeHelper.compute_accept_key(
+          "dGhlIHNhbXBsZSBub25jZQ==")
+      h.assert_eq[String](expected_key, result.accept_key)
+      h.assert_eq[USize](0, result.remaining.size())
+    | _HandshakeNeedMore =>
+      h.fail("expected result, got need more")
+    | let err: HandshakeError =>
+      h.fail("expected result, got error")
+    end
+
+class \nodoc\ iso _TestHandshakeRemainingBytes is UnitTest
+  """Bytes after \\r\\n\\r\\n are returned as remaining."""
+  fun name(): String => "handshake/remaining_bytes"
+
+  fun apply(h: TestHelper) ? =>
+    let request_data = _TestHandshakeHelper.valid_request()
+    // Append extra bytes after the request
+    let extra: Array[U8] val = recover val [as U8: 0x81; 0x85] end
+    let combined = recover iso
+      let c = Array[U8]
+      c.append(consume request_data)
+      c.append(extra)
+      c
+    end
+    let parser = _HandshakeParser
+    match parser(consume combined, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[USize](2, result.remaining.size())
+      h.assert_eq[U8](0x81, result.remaining(0)?)
+      h.assert_eq[U8](0x85, result.remaining(1)?)
+    | _HandshakeNeedMore => h.fail("expected result")
+    | let err: HandshakeError => h.fail("expected result")
+    end
+
+class \nodoc\ iso _TestHandshakeTooLarge is UnitTest
+  """Request exceeding max size produces HandshakeRequestTooLarge."""
+  fun name(): String => "handshake/too_large"
+
+  fun apply(h: TestHelper) =>
+    let parser = _HandshakeParser
+    let data = _TestHandshakeHelper.valid_request()
+    match parser(consume data, 10) // tiny max_size
+    | HandshakeRequestTooLarge => None // expected
+    | _HandshakeNeedMore => h.fail("expected too large error")
+    | let _: _HandshakeResult => h.fail("expected too large error")
+    | let err: HandshakeError => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestHandshakeInvalidMethod is UnitTest
+  """Non-GET method produces HandshakeInvalidHTTP."""
+  fun name(): String => "handshake/invalid_method"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("POST / HTTP/1.1\r\n")
+        .>append("Host: localhost\r\n")
+        .>append("Upgrade: websocket\r\n")
+        .>append("Connection: Upgrade\r\n")
+        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+        .>append("Sec-WebSocket-Version: 13\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | HandshakeInvalidHTTP => None // expected
+    | _HandshakeNeedMore => h.fail("expected error")
+    | let _: _HandshakeResult => h.fail("expected error")
+    | let err: HandshakeError => h.fail("wrong error: " + err.string())
+    end
+
+class \nodoc\ iso _TestHandshakeMissingUpgrade is UnitTest
+  """Missing Upgrade header produces HandshakeMissingUpgrade."""
+  fun name(): String => "handshake/missing_upgrade"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("GET / HTTP/1.1\r\n")
+        .>append("Host: localhost\r\n")
+        .>append("Connection: Upgrade\r\n")
+        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+        .>append("Sec-WebSocket-Version: 13\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | HandshakeMissingUpgrade => None // expected
+    | _HandshakeNeedMore => h.fail("expected error")
+    | let _: _HandshakeResult => h.fail("expected error")
+    | let err: HandshakeError => h.fail("wrong error: " + err.string())
+    end
+
+class \nodoc\ iso _TestHandshakeWrongVersion is UnitTest
+  """Wrong Sec-WebSocket-Version produces HandshakeWrongVersion."""
+  fun name(): String => "handshake/wrong_version"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("GET / HTTP/1.1\r\n")
+        .>append("Host: localhost\r\n")
+        .>append("Upgrade: websocket\r\n")
+        .>append("Connection: Upgrade\r\n")
+        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+        .>append("Sec-WebSocket-Version: 8\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | HandshakeWrongVersion => None // expected
+    | _HandshakeNeedMore => h.fail("expected error")
+    | let _: _HandshakeResult => h.fail("expected error")
+    | let err: HandshakeError => h.fail("wrong error: " + err.string())
+    end
+
+class \nodoc\ iso _TestHandshakeMissingKey is UnitTest
+  """Missing Sec-WebSocket-Key produces HandshakeMissingKey."""
+  fun name(): String => "handshake/missing_key"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("GET / HTTP/1.1\r\n")
+        .>append("Host: localhost\r\n")
+        .>append("Upgrade: websocket\r\n")
+        .>append("Connection: Upgrade\r\n")
+        .>append("Sec-WebSocket-Version: 13\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | HandshakeMissingKey => None // expected
+    | _HandshakeNeedMore => h.fail("expected error")
+    | let _: _HandshakeResult => h.fail("expected error")
+    | let err: HandshakeError => h.fail("wrong error: " + err.string())
+    end
+
+class \nodoc\ iso _TestHandshakeCaseInsensitive is UnitTest
+  """Header values are matched case-insensitively."""
+  fun name(): String => "handshake/case_insensitive"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("GET / HTTP/1.1\r\n")
+        .>append("Host: localhost\r\n")
+        .>append("upgrade: WebSocket\r\n")
+        .>append("connection: Upgrade\r\n")
+        .>append("sec-websocket-key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+        .>append("sec-websocket-version: 13\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[String]("/", result.request.uri)
+    | _HandshakeNeedMore => h.fail("expected result")
+    | let err: HandshakeError => h.fail("unexpected error: " + err.string())
+    end
+
+class \nodoc\ iso _TestHandshakeIncremental is UnitTest
+  """Request split across multiple calls is assembled correctly."""
+  fun name(): String => "handshake/incremental"
+
+  fun apply(h: TestHelper) =>
+    let full_request = _TestHandshakeHelper.valid_request()
+    let full_size = full_request.size()
+
+    // Split at roughly the middle
+    let split_at = full_size / 2
+    let parser = _HandshakeParser
+
+    let first_half = recover iso
+      let a = Array[U8](split_at)
+      var i: USize = 0
+      while i < split_at do
+        try a.push(full_request(i)?) else _Unreachable() end
+        i = i + 1
+      end
+      a
+    end
+
+    match parser(consume first_half, 8192)
+    | _HandshakeNeedMore => None // expected
+    | let _: _HandshakeResult => h.fail("too early")
+    | let err: HandshakeError => h.fail("unexpected error")
+    end
+
+    let second_half = recover iso
+      let a = Array[U8](full_size - split_at)
+      var i: USize = split_at
+      while i < full_size do
+        try a.push(full_request(i)?) else _Unreachable() end
+        i = i + 1
+      end
+      a
+    end
+
+    match parser(consume second_half, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[String]("/", result.request.uri)
+    | _HandshakeNeedMore => h.fail("expected result after second chunk")
+    | let err: HandshakeError => h.fail("unexpected error on second chunk")
+    end
+
+class \nodoc\ iso _TestHandshakeRfc6455AcceptKey is UnitTest
+  """
+  Accept key matches the RFC 6455 Section 4.2.2 example.
+
+  Key: dGhlIHNhbXBsZSBub25jZQ==
+  Expected Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+  """
+  fun name(): String => "handshake/rfc6455_accept_key"
+
+  fun apply(h: TestHelper) =>
+    let parser = _HandshakeParser
+    let data = _TestHandshakeHelper.valid_request()
+    match parser(consume data, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[String]("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", result.accept_key)
+    | _HandshakeNeedMore => h.fail("expected result")
+    | let err: HandshakeError => h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHandshakeConnectionMultiToken is UnitTest
+  """
+  Connection header with multiple comma-separated tokens containing
+  'Upgrade' is accepted.
+  """
+  fun name(): String => "handshake/connection_multi_token"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("GET / HTTP/1.1\r\n")
+        .>append("Host: localhost\r\n")
+        .>append("Upgrade: websocket\r\n")
+        .>append("Connection: keep-alive, Upgrade\r\n")
+        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+        .>append("Sec-WebSocket-Version: 13\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[String]("/", result.request.uri)
+    | _HandshakeNeedMore => h.fail("expected result")
+    | let err: HandshakeError => h.fail("unexpected error: " + err.string())
+    end
+
+class \nodoc\ iso _TestHandshakePropertyValidRequests is Property1[String]
+  """Valid upgrade requests with random URIs always parse successfully."""
+  fun name(): String => "handshake/property_valid_requests"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_letters(where min = 1, max = 50)
+
+  fun property(uri_suffix: String, h: PropertyHelper) =>
+    let test_uri: String val = "/" + uri_suffix
+    let data = _TestHandshakeHelper.valid_request(where uri = test_uri)
+    let parser = _HandshakeParser
+    match parser(consume data, 8192)
+    | let result: _HandshakeResult =>
+      h.assert_eq[String](test_uri, result.request.uri)
+    | _HandshakeNeedMore =>
+      h.fail("expected result for uri: " + test_uri)
+    | let err: HandshakeError =>
+      h.fail("unexpected error for uri: " + test_uri)
+    end

--- a/websockets/_test_utf8_validator.pony
+++ b/websockets/_test_utf8_validator.pony
@@ -1,0 +1,133 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _TestUtf8ValidAscii is UnitTest
+  """Valid ASCII bytes are accepted."""
+  fun name(): String => "utf8/valid_ascii"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(_Utf8Validator.is_valid("Hello, world!".array()))
+
+class \nodoc\ iso _TestUtf8ValidEmpty is UnitTest
+  """Empty input is valid."""
+  fun name(): String => "utf8/valid_empty"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(_Utf8Validator.is_valid(recover val Array[U8] end))
+
+class \nodoc\ iso _TestUtf8ValidTwoByte is UnitTest
+  """Valid two-byte UTF-8 sequence (e.g., U+00E9 'e with acute')."""
+  fun name(): String => "utf8/valid_two_byte"
+
+  fun apply(h: TestHelper) =>
+    // U+00E9 = 0xC3 0xA9
+    h.assert_true(_Utf8Validator.is_valid(
+      recover val [as U8: 0xC3; 0xA9] end))
+
+class \nodoc\ iso _TestUtf8ValidThreeByte is UnitTest
+  """Valid three-byte UTF-8 sequence (e.g., U+4E16 CJK character)."""
+  fun name(): String => "utf8/valid_three_byte"
+
+  fun apply(h: TestHelper) =>
+    // U+4E16 = 0xE4 0xB8 0x96
+    h.assert_true(_Utf8Validator.is_valid(
+      recover val [as U8: 0xE4; 0xB8; 0x96] end))
+
+class \nodoc\ iso _TestUtf8ValidFourByte is UnitTest
+  """Valid four-byte UTF-8 sequence (e.g., U+1F600 emoji)."""
+  fun name(): String => "utf8/valid_four_byte"
+
+  fun apply(h: TestHelper) =>
+    // U+1F600 = 0xF0 0x9F 0x98 0x80
+    h.assert_true(_Utf8Validator.is_valid(
+      recover val [as U8: 0xF0; 0x9F; 0x98; 0x80] end))
+
+class \nodoc\ iso _TestUtf8InvalidTruncated is UnitTest
+  """Truncated multi-byte sequence is rejected."""
+  fun name(): String => "utf8/invalid_truncated"
+
+  fun apply(h: TestHelper) =>
+    // Two-byte lead without continuation
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xC3] end))
+    // Three-byte lead with only one continuation
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xE4; 0xB8] end))
+    // Four-byte lead with only two continuations
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xF0; 0x9F; 0x98] end))
+
+class \nodoc\ iso _TestUtf8InvalidOverlong is UnitTest
+  """Overlong encodings are rejected."""
+  fun name(): String => "utf8/invalid_overlong"
+
+  fun apply(h: TestHelper) =>
+    // Overlong two-byte encoding of U+0000 (0xC0 0x80)
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xC0; 0x80] end))
+    // Overlong two-byte encoding of U+007F (0xC1 0xBF)
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xC1; 0xBF] end))
+    // Overlong three-byte encoding of U+007F (0xE0 0x81 0xBF)
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xE0; 0x81; 0xBF] end))
+    // Overlong four-byte encoding (0xF0 0x80 0x80 0x80)
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xF0; 0x80; 0x80; 0x80] end))
+
+class \nodoc\ iso _TestUtf8InvalidSurrogate is UnitTest
+  """Surrogate halves (U+D800-U+DFFF) are rejected."""
+  fun name(): String => "utf8/invalid_surrogate"
+
+  fun apply(h: TestHelper) =>
+    // U+D800 = 0xED 0xA0 0x80
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xED; 0xA0; 0x80] end))
+    // U+DFFF = 0xED 0xBF 0xBF
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xED; 0xBF; 0xBF] end))
+
+class \nodoc\ iso _TestUtf8InvalidAboveMax is UnitTest
+  """Codepoints above U+10FFFF are rejected."""
+  fun name(): String => "utf8/invalid_above_max"
+
+  fun apply(h: TestHelper) =>
+    // 0xF4 0x90 0x80 0x80 = U+110000 (first invalid)
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xF4; 0x90; 0x80; 0x80] end))
+    // Lead byte 0xF5 (always invalid)
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xF5; 0x80; 0x80; 0x80] end))
+
+class \nodoc\ iso _TestUtf8InvalidContinuationFirst is UnitTest
+  """Continuation byte at start of sequence is rejected."""
+  fun name(): String => "utf8/invalid_continuation_first"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0x80] end))
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: 0xBF] end))
+
+class \nodoc\ iso _TestUtf8PropertyValidStrings is Property1[String]
+  """Valid Unicode strings encoded as UTF-8 are accepted."""
+  fun name(): String => "utf8/property_valid_strings"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_printable(
+      where min = 0, max = 100)
+
+  fun property(sample: String, h: PropertyHelper) =>
+    h.assert_true(_Utf8Validator.is_valid(sample.array()))
+
+class \nodoc\ iso _TestUtf8PropertyInvalidByte is Property1[U8]
+  """Bytes 0xF5-0xFF at start of sequence are always invalid."""
+  fun name(): String => "utf8/property_invalid_lead_byte"
+
+  fun gen(): Generator[U8] =>
+    // Generate bytes in range 0xF5..0xFF
+    Generators.u8(where min = 0xF5)
+
+  fun property(sample: U8, h: PropertyHelper) =>
+    h.assert_false(_Utf8Validator.is_valid(
+      recover val [as U8: sample; 0x80; 0x80; 0x80] end))

--- a/websockets/_utf8_validator.pony
+++ b/websockets/_utf8_validator.pony
@@ -1,0 +1,67 @@
+primitive _Utf8Validator
+  """
+  Validates that a byte sequence is well-formed UTF-8.
+
+  Checks all encoding rules: valid lead bytes, correct continuation byte
+  counts, no overlong encodings, no surrogates (U+D800..U+DFFF), and no
+  codepoints above U+10FFFF.
+  """
+
+  fun is_valid(data: Array[U8] box): Bool =>
+    """Return true if `data` is valid UTF-8."""
+    var i: USize = 0
+    let size = data.size()
+
+    while i < size do
+      try
+        let b0 = data(i)?
+
+        if b0 < 0x80 then
+          // Single byte (ASCII)
+          i = i + 1
+        elseif (b0 and 0xE0) == 0xC0 then
+          // Two-byte sequence
+          if (i + 1) >= size then return false end
+          let b1 = data(i + 1)?
+          if (b1 and 0xC0) != 0x80 then return false end
+          // Reject overlong: smallest two-byte is U+0080 (lead byte 0xC2)
+          if b0 < 0xC2 then return false end
+          i = i + 2
+        elseif (b0 and 0xF0) == 0xE0 then
+          // Three-byte sequence
+          if (i + 2) >= size then return false end
+          let b1 = data(i + 1)?
+          let b2 = data(i + 2)?
+          if (b1 and 0xC0) != 0x80 then return false end
+          if (b2 and 0xC0) != 0x80 then return false end
+          // Reject overlong: E0 requires b1 >= A0
+          if (b0 == 0xE0) and (b1 < 0xA0) then return false end
+          // Reject surrogates: ED requires b1 < A0
+          if (b0 == 0xED) and (b1 >= 0xA0) then return false end
+          i = i + 3
+        elseif (b0 and 0xF8) == 0xF0 then
+          // Four-byte sequence
+          if (i + 3) >= size then return false end
+          let b1 = data(i + 1)?
+          let b2 = data(i + 2)?
+          let b3 = data(i + 3)?
+          if (b1 and 0xC0) != 0x80 then return false end
+          if (b2 and 0xC0) != 0x80 then return false end
+          if (b3 and 0xC0) != 0x80 then return false end
+          // Reject overlong: F0 requires b1 >= 90
+          if (b0 == 0xF0) and (b1 < 0x90) then return false end
+          // Reject above U+10FFFF: F4 requires b1 < 90
+          if (b0 == 0xF4) and (b1 >= 0x90) then return false end
+          // Reject lead bytes above F4
+          if b0 > 0xF4 then return false end
+          i = i + 4
+        else
+          // Invalid lead byte (continuation byte or 0xF5+)
+          return false
+        end
+      else
+        _Unreachable()
+        return false
+      end
+    end
+    true

--- a/websockets/close_code.pony
+++ b/websockets/close_code.pony
@@ -1,0 +1,50 @@
+// WebSocket close status codes defined in RFC 6455 Section 7.4.1.
+type CloseCode is
+  ( CloseNormal
+  | CloseGoingAway
+  | CloseProtocolError
+  | CloseUnsupportedData
+  | CloseInvalidPayload
+  | ClosePolicyViolation
+  | CloseMessageTooBig
+  | CloseInternalError )
+
+primitive CloseNormal is Stringable
+  """Normal closure (1000). The connection fulfilled its purpose."""
+  fun code(): U16 => 1000
+  fun string(): String iso^ => "1000 Normal Closure".clone()
+
+primitive CloseGoingAway is Stringable
+  """Going away (1001). The endpoint is shutting down."""
+  fun code(): U16 => 1001
+  fun string(): String iso^ => "1001 Going Away".clone()
+
+primitive CloseProtocolError is Stringable
+  """Protocol error (1002). A protocol violation was detected."""
+  fun code(): U16 => 1002
+  fun string(): String iso^ => "1002 Protocol Error".clone()
+
+primitive CloseUnsupportedData is Stringable
+  """Unsupported data (1003). An unsupported data type was received."""
+  fun code(): U16 => 1003
+  fun string(): String iso^ => "1003 Unsupported Data".clone()
+
+primitive CloseInvalidPayload is Stringable
+  """Invalid payload (1007). A message payload was not valid."""
+  fun code(): U16 => 1007
+  fun string(): String iso^ => "1007 Invalid Payload".clone()
+
+primitive ClosePolicyViolation is Stringable
+  """Policy violation (1008). A policy was violated."""
+  fun code(): U16 => 1008
+  fun string(): String iso^ => "1008 Policy Violation".clone()
+
+primitive CloseMessageTooBig is Stringable
+  """Message too big (1009). A message exceeded the size limit."""
+  fun code(): U16 => 1009
+  fun string(): String iso^ => "1009 Message Too Big".clone()
+
+primitive CloseInternalError is Stringable
+  """Internal error (1011). An unexpected server error occurred."""
+  fun code(): U16 => 1011
+  fun string(): String iso^ => "1011 Internal Error".clone()

--- a/websockets/handshake_error.pony
+++ b/websockets/handshake_error.pony
@@ -1,0 +1,35 @@
+// Errors that can occur during WebSocket HTTP upgrade handshake validation.
+type HandshakeError is
+  ( HandshakeRequestTooLarge
+  | HandshakeInvalidHTTP
+  | HandshakeMissingUpgrade
+  | HandshakeWrongVersion
+  | HandshakeMissingKey )
+
+primitive HandshakeRequestTooLarge is Stringable
+  """The HTTP upgrade request exceeded the maximum allowed size."""
+  fun string(): String iso^ =>
+    "Handshake request too large".clone()
+
+primitive HandshakeInvalidHTTP is Stringable
+  """The HTTP request line was malformed or not a GET request."""
+  fun string(): String iso^ =>
+    "Invalid HTTP request".clone()
+
+primitive HandshakeMissingUpgrade is Stringable
+  """
+  The required Upgrade and Connection headers were missing or had
+  incorrect values.
+  """
+  fun string(): String iso^ =>
+    "Missing or invalid Upgrade/Connection headers".clone()
+
+primitive HandshakeWrongVersion is Stringable
+  """The Sec-WebSocket-Version header was not 13."""
+  fun string(): String iso^ =>
+    "Wrong WebSocket version (expected 13)".clone()
+
+primitive HandshakeMissingKey is Stringable
+  """The Sec-WebSocket-Key header was missing."""
+  fun string(): String iso^ =>
+    "Missing Sec-WebSocket-Key header".clone()

--- a/websockets/upgrade_request.pony
+++ b/websockets/upgrade_request.pony
@@ -1,0 +1,30 @@
+class val UpgradeRequest
+  """
+  A parsed HTTP upgrade request from a WebSocket client.
+
+  Provides access to the request URI and headers. Header lookups are
+  case-insensitive per HTTP/1.1 (RFC 7230 Section 3.2).
+  """
+  let uri: String
+  let _headers: Array[(String val, String val)] val
+
+  new val create(uri': String, headers': Array[(String val, String val)] val) =>
+    """Create an upgrade request with the given URI and headers."""
+    uri = uri'
+    _headers = headers'
+
+  fun header(name: String): (String val | None) =>
+    """
+    Look up a header value by name (case-insensitive).
+
+    Returns the first matching header value, or `None` if not found.
+    Header names are stored pre-lowered by `_HandshakeParser`, so this
+    only needs to lower the lookup key.
+    """
+    let lower: String val = name.lower()
+    for (k, v) in _headers.values() do
+      if k == lower then
+        return v
+      end
+    end
+    None

--- a/websockets/websocket_config.pony
+++ b/websockets/websocket_config.pony
@@ -1,0 +1,30 @@
+class val WebSocketConfig
+  """
+  Immutable configuration for a WebSocket connection.
+
+  All fields have sensible defaults. Create with named arguments to
+  override specific values:
+
+  ```pony
+  let config = WebSocketConfig(where
+    host' = "0.0.0.0",
+    port' = "9090",
+    max_message_size' = 4_194_304)
+  ```
+  """
+  let host: String
+  let port: String
+  let max_message_size: USize
+  let max_handshake_size: USize
+
+  new val create(
+    host': String = "localhost",
+    port': String = "8080",
+    max_message_size': USize = 1_048_576,
+    max_handshake_size': USize = 8192)
+  =>
+    """Create WebSocket configuration with optional overrides."""
+    host = host'
+    port = port'
+    max_message_size = max_message_size'
+    max_handshake_size = max_handshake_size'

--- a/websockets/websocket_lifecycle_event_receiver.pony
+++ b/websockets/websocket_lifecycle_event_receiver.pony
@@ -1,0 +1,53 @@
+trait WebSocketLifecycleEventReceiver
+  """
+  WebSocket lifecycle callbacks delivered to the connection actor.
+
+  All callbacks have default no-op implementations. Override only the
+  callbacks your actor needs. For most servers, `on_text_message()` or
+  `on_binary_message()` is the main callback — it delivers complete,
+  reassembled messages after all fragments are received and validated.
+
+  Override `on_upgrade_request()` to inspect the HTTP upgrade request
+  before accepting the connection (e.g., checking the URI path or
+  Origin header). Return `false` to reject with 403 Forbidden.
+
+  Callbacks are invoked synchronously inside the actor that owns the
+  `WebSocketServer`. The protocol class handles framing, masking,
+  fragmentation, and the close handshake internally, delivering only
+  application-level events through this interface.
+  """
+
+  fun ref on_upgrade_request(request: UpgradeRequest val): Bool =>
+    """
+    Called when a valid upgrade request is received, before the
+    connection is accepted.
+
+    Return `true` to accept (sends 101 Switching Protocols) or `false`
+    to reject (sends 403 Forbidden and closes TCP). The default
+    implementation accepts all connections.
+    """
+    true
+
+  fun ref on_open(request: UpgradeRequest val) =>
+    """Called after the WebSocket handshake completes successfully."""
+    None
+
+  fun ref on_text_message(data: String val) =>
+    """Called when a complete text message is received."""
+    None
+
+  fun ref on_binary_message(data: Array[U8] val) =>
+    """Called when a complete binary message is received."""
+    None
+
+  fun ref on_closed() =>
+    """Called when the WebSocket connection closes."""
+    None
+
+  fun ref on_throttled() =>
+    """Called when backpressure is applied on the connection."""
+    None
+
+  fun ref on_unthrottled() =>
+    """Called when backpressure is released on the connection."""
+    None

--- a/websockets/websocket_server.pony
+++ b/websockets/websocket_server.pony
@@ -1,0 +1,347 @@
+use lori = "lori"
+use ssl_net = "ssl/net"
+
+class WebSocketServer is lori.ServerLifecycleEventReceiver
+  """
+  WebSocket protocol handler that manages handshaking, framing, and
+  connection lifecycle for a single WebSocket connection.
+
+  This class is NOT an actor — it lives inside the user's actor and
+  handles protocol details. The user's actor implements
+  `WebSocketServerActor` and stores this class as a field.
+
+  Use `none()` as the field default so that `this` is `ref` in the
+  actor constructor body, then replace with `create()` or `ssl()`:
+
+  ```pony
+  actor MyHandler is WebSocketServerActor
+    var _ws: WebSocketServer = WebSocketServer.none()
+
+    new create(auth: lori.TCPServerAuth, fd: U32,
+      config: WebSocketConfig val)
+    =>
+      _ws = WebSocketServer(auth, fd, this, config)
+
+    fun ref _websocket(): WebSocketServer => _ws
+  ```
+  """
+  let _lifecycle_event_receiver: (WebSocketLifecycleEventReceiver ref | None)
+  let _config: (WebSocketConfig val | None)
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _state: _ConnectionState = _Closed
+  var _handshake_parser: _HandshakeParser = _HandshakeParser
+  var _frame_parser: _FrameParser = _FrameParser
+  var _reassembler: _FragmentReassembler = _FragmentReassembler
+
+  new none() =>
+    """
+    Create a placeholder protocol instance.
+
+    Used as the default value for the `_ws` field in
+    `WebSocketServerActor` implementations, allowing `this` to be `ref`
+    in the actor constructor body. The placeholder is immediately
+    replaced by `create()` or `ssl()` — its methods must never be
+    called.
+    """
+    _lifecycle_event_receiver = None
+    _config = None
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    server_actor: WebSocketServerActor ref,
+    config: WebSocketConfig val)
+  =>
+    """Create a plain WebSocket (WS) connection handler."""
+    _lifecycle_event_receiver = server_actor
+    _config = config
+    _state = _Handshaking
+    _tcp_connection =
+      lori.TCPConnection.server(auth, fd, server_actor, this)
+
+  new ssl(
+    auth: lori.TCPServerAuth,
+    ssl_ctx: ssl_net.SSLContext val,
+    fd: U32,
+    server_actor: WebSocketServerActor ref,
+    config: WebSocketConfig val)
+  =>
+    """Create a secure WebSocket (WSS) connection handler."""
+    _lifecycle_event_receiver = server_actor
+    _config = config
+    _state = _Handshaking
+    _tcp_connection =
+      lori.TCPConnection.ssl_server(
+        auth, ssl_ctx, fd, server_actor, this)
+
+  // -- Public send API --
+
+  fun ref send_text(data: String val) =>
+    """Send a text message to the client."""
+    _state.send_text(this, data)
+
+  fun ref send_binary(data: Array[U8] val) =>
+    """Send a binary message to the client."""
+    _state.send_binary(this, data)
+
+  fun ref close(
+    code: CloseCode = CloseNormal,
+    reason: String val = "")
+  =>
+    """
+    Initiate a close handshake with the client.
+
+    Sends a close frame and transitions to the Closing state. The
+    connection will close after the client responds with its own close
+    frame, or if TCP drops.
+    """
+    _state.close(this, code, reason)
+
+  // -- lori ServerLifecycleEventReceiver --
+
+  fun ref _connection(): lori.TCPConnection => _tcp_connection
+
+  fun ref _on_started() => None
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _state.on_received(this, consume data)
+
+  fun ref _on_closed() =>
+    _state.on_closed(this)
+
+  fun ref _on_start_failure() =>
+    _state = _Closed
+
+  fun ref _on_throttled() =>
+    _state.on_throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _state.on_unthrottled(this)
+
+  fun ref _on_sent(token: lori.SendToken) =>
+    _state.on_sent(this, token)
+
+  fun ref _on_send_failed(token: lori.SendToken) => None
+
+  fun ref _on_idle_timeout() =>
+    _state.on_idle_timeout(this)
+
+  fun ref _on_tls_ready() => None
+
+  fun ref _on_tls_failure() => None
+
+  // -- Internal methods called by state classes --
+
+  fun ref _set_state(state: _ConnectionState) =>
+    """Transition to a new connection state."""
+    _state = state
+
+  fun ref _feed_handshake(data: Array[U8] iso) =>
+    """Process incoming data during the handshake phase."""
+    let max_size = match _config
+      | let c: WebSocketConfig val => c.max_handshake_size
+      | None => _Unreachable(); return
+      end
+
+    match _handshake_parser(consume data, max_size)
+    | _HandshakeNeedMore => None
+    | let result: _HandshakeResult =>
+      match _lifecycle_event_receiver
+      | let r: WebSocketLifecycleEventReceiver ref =>
+        if r.on_upgrade_request(result.request) then
+          // Accept: send 101 response
+          _send_101_response(result.accept_key)
+          _state = _Open
+          _fire_on_open(result.request)
+          // Forward any remaining bytes to frame parser
+          if result.remaining.size() > 0 then
+            _feed_frames_from_val(result.remaining)
+          end
+        else
+          // Reject: send 403 and close
+          _send_http_error("403 Forbidden")
+          _tcp_connection.close()
+          _state = _Closed
+        end
+      | None => _Unreachable()
+      end
+    | let err: HandshakeError =>
+      match err
+      | HandshakeWrongVersion =>
+        _send_http_error("426 Upgrade Required",
+          "Sec-WebSocket-Version: 13\r\n")
+      else
+        _send_http_error("400 Bad Request")
+      end
+      _tcp_connection.close()
+      _state = _Closed
+    end
+
+  fun ref _feed_frames(data: Array[U8] iso) =>
+    """Process incoming frame data in the Open state."""
+    let data_val: Array[U8] val = consume data
+    _feed_frames_from_val(data_val)
+
+  fun ref _feed_frames_from_val(data: Array[U8] val) =>
+    """Process incoming frame data from a val array."""
+    match _frame_parser.parse(data)
+    | let frames: Array[_ParsedFrame val] val =>
+      for frame in frames.values() do
+        _dispatch_frame(frame)
+        // Check if state changed to Closed during dispatch
+        match _state
+        | let _: _Closed => return
+        end
+      end
+    | let err: _FrameError =>
+      _send_frame(_FrameEncoder.close(err.code))
+      _fire_on_closed()
+      _tcp_connection.close()
+      _state = _Closed
+    end
+
+  fun ref _feed_frames_closing(data: Array[U8] iso) =>
+    """Process incoming frame data in the Closing state."""
+    let data_val: Array[U8] val = consume data
+    match _frame_parser.parse(data_val)
+    | let frames: Array[_ParsedFrame val] val =>
+      for frame in frames.values() do
+        match frame.opcode
+        | 0x08 =>
+          // Close response received — complete the close handshake
+          _fire_on_closed()
+          _tcp_connection.close()
+          _state = _Closed
+          return
+        | 0x09 =>
+          // Ping — still respond with pong during close
+          _send_frame(_FrameEncoder.pong(frame.payload))
+        | 0x0A => None // Pong — discard
+        else
+          None // Data frames — discard during closing
+        end
+      end
+    | let err: _FrameError =>
+      _fire_on_closed()
+      _tcp_connection.close()
+      _state = _Closed
+    end
+
+  fun ref _dispatch_frame(frame: _ParsedFrame val) =>
+    """Dispatch a parsed frame by opcode in the Open state."""
+    match frame.opcode
+    | 0x09 =>
+      // Ping — auto-respond with pong
+      _send_frame(_FrameEncoder.pong(frame.payload))
+    | 0x0A =>
+      // Pong — discard
+      None
+    | 0x08 =>
+      // Close — echo the client's close payload (status code + reason)
+      if frame.payload.size() >= 2 then
+        _send_frame(_FrameEncoder.close_payload(frame.payload))
+      else
+        _send_frame(_FrameEncoder.close_empty())
+      end
+      _fire_on_closed()
+      _tcp_connection.close()
+      _state = _Closed
+    else
+      // Data frame (text, binary, continuation) — reassemble
+      let max_size = match _config
+        | let c: WebSocketConfig val => c.max_message_size
+        | None => _Unreachable(); return
+        end
+
+      match _reassembler.frame(
+        frame.fin, frame.opcode, frame.payload, max_size)
+      | let msg: _CompleteMessage =>
+        if msg.is_text then
+          _fire_on_text(String.from_array(msg.data))
+        else
+          _fire_on_binary(msg.data)
+        end
+      | _FragmentContinue => None
+      | let err: _ReassemblyError =>
+        _send_frame(_FrameEncoder.close(err.code))
+        _fire_on_closed()
+        _tcp_connection.close()
+        _state = _Closed
+      end
+    end
+
+  fun ref _send_frame(data: Array[U8] val) =>
+    """
+    Send a framed WebSocket message over TCP.
+
+    Ignores send errors: `SendErrorNotConnected` means the connection is
+    already closing, `SendErrorNotWriteable` means backpressure. In both
+    cases the frame is silently dropped — this matches v1 fire-and-forget
+    send semantics.
+    """
+    _tcp_connection.send(data)
+
+  fun ref _send_101_response(accept_key: String val) =>
+    """Send the HTTP 101 Switching Protocols response."""
+    let response: String val = recover val
+      String(256)
+        .>append("HTTP/1.1 101 Switching Protocols\r\n")
+        .>append("Upgrade: websocket\r\n")
+        .>append("Connection: Upgrade\r\n")
+        .>append("Sec-WebSocket-Accept: ")
+        .>append(accept_key)
+        .>append("\r\n\r\n")
+    end
+    _tcp_connection.send(response)
+
+  fun ref _send_http_error(
+    status: String val,
+    extra_headers: String val = "")
+  =>
+    """Send an HTTP error response and close."""
+    let response: String val = recover val
+      String(256)
+        .>append("HTTP/1.1 ")
+        .>append(status)
+        .>append("\r\n")
+        .>append(extra_headers)
+        .>append("Content-Length: 0\r\n\r\n")
+    end
+    _tcp_connection.send(response)
+
+  fun ref _fire_on_open(request: UpgradeRequest val) =>
+    match _lifecycle_event_receiver
+    | let r: WebSocketLifecycleEventReceiver ref => r.on_open(request)
+    | None => _Unreachable()
+    end
+
+  fun ref _fire_on_text(data: String val) =>
+    match _lifecycle_event_receiver
+    | let r: WebSocketLifecycleEventReceiver ref => r.on_text_message(data)
+    | None => _Unreachable()
+    end
+
+  fun ref _fire_on_binary(data: Array[U8] val) =>
+    match _lifecycle_event_receiver
+    | let r: WebSocketLifecycleEventReceiver ref =>
+      r.on_binary_message(data)
+    | None => _Unreachable()
+    end
+
+  fun ref _fire_on_closed() =>
+    match _lifecycle_event_receiver
+    | let r: WebSocketLifecycleEventReceiver ref => r.on_closed()
+    | None => _Unreachable()
+    end
+
+  fun ref _fire_on_throttled() =>
+    match _lifecycle_event_receiver
+    | let r: WebSocketLifecycleEventReceiver ref => r.on_throttled()
+    | None => _Unreachable()
+    end
+
+  fun ref _fire_on_unthrottled() =>
+    match _lifecycle_event_receiver
+    | let r: WebSocketLifecycleEventReceiver ref => r.on_unthrottled()
+    | None => _Unreachable()
+    end

--- a/websockets/websocket_server_actor.pony
+++ b/websockets/websocket_server_actor.pony
@@ -1,0 +1,37 @@
+use lori = "lori"
+
+trait tag WebSocketServerActor is
+  (lori.TCPConnectionActor & WebSocketLifecycleEventReceiver)
+  """
+  Trait for actors that serve WebSocket connections.
+
+  Extends `TCPConnectionActor` (for lori ASIO plumbing) and
+  `WebSocketLifecycleEventReceiver` (for WebSocket-level callbacks).
+  The actor stores a `WebSocketServer` as a field and implements
+  `_websocket()` to return it. All other required methods
+  have default implementations that delegate to the protocol.
+
+  Minimal implementation:
+
+  ```pony
+  actor MyHandler is WebSocketServerActor
+    var _ws: WebSocketServer = WebSocketServer.none()
+
+    new create(auth: lori.TCPServerAuth, fd: U32,
+      config: WebSocketConfig)
+    =>
+      _ws = WebSocketServer(auth, fd, this, config)
+
+    fun ref _websocket(): WebSocketServer => _ws
+
+    fun ref on_text_message(data: String val) =>
+      _ws.send_text(data)  // echo back
+  ```
+  """
+
+  fun ref _websocket(): WebSocketServer
+    """Return the protocol instance owned by this actor."""
+
+  fun ref _connection(): lori.TCPConnection =>
+    """Delegates to the protocol's TCP connection."""
+    _websocket()._connection()

--- a/websockets/websockets.pony
+++ b/websockets/websockets.pony
@@ -1,3 +1,121 @@
 """
-WebSockets for Pony.
+# WebSockets
+
+A WebSocket server library for Pony built on
+[lori](https://github.com/ponylang/lori).
+
+## Architecture
+
+The library follows lori's "your actor IS the connection" pattern:
+
+- A **listener actor** (`lori.TCPListenerActor`) accepts TCP connections.
+  On each accept, it creates a new connection actor.
+- A **connection actor** (`WebSocketServerActor`) owns a `WebSocketServer`
+  protocol handler and receives WebSocket lifecycle callbacks.
+
+The `WebSocketServer` class handles all protocol details — HTTP upgrade
+handshake, frame parsing, masking, fragmentation, and the close
+handshake — and delivers application-level events through the
+`WebSocketLifecycleEventReceiver` callbacks.
+
+## Quick Start
+
+A minimal echo server:
+
+```pony
+use lori = "lori"
+use "websockets"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+    let config = WebSocketConfig(where host' = "localhost", port' = "8080")
+    EchoListener(auth, config)
+
+actor EchoListener is lori.TCPListenerActor
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _server_auth: lori.TCPServerAuth
+  let _config: WebSocketConfig val
+
+  new create(auth: lori.TCPListenAuth, config: WebSocketConfig val) =>
+    _server_auth = lori.TCPServerAuth(auth)
+    _config = config
+    _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
+
+  fun ref _listener(): lori.TCPListener => _tcp_listener
+
+  fun ref _on_accept(fd: U32): EchoHandler =>
+    EchoHandler(_server_auth, fd, _config)
+
+  fun ref _on_listen_failure() => None
+
+actor EchoHandler is WebSocketServerActor
+  var _ws: WebSocketServer = WebSocketServer.none()
+
+  new create(auth: lori.TCPServerAuth, fd: U32,
+    config: WebSocketConfig val)
+  =>
+    _ws = WebSocketServer(auth, fd, this, config)
+
+  fun ref _websocket(): WebSocketServer => _ws
+
+  fun ref on_text_message(data: String val) =>
+    _ws.send_text(data)
+
+  fun ref on_binary_message(data: Array[U8] val) =>
+    _ws.send_binary(data)
+```
+
+## WSS (Secure WebSocket)
+
+For TLS-encrypted connections, use `WebSocketServer.ssl()` instead of
+`create()` and pass an `ssl.net.SSLContext`:
+
+```pony
+use ssl_net = "ssl/net"
+
+// In the listener's _on_accept (store _server_auth from auth in constructor):
+fun ref _on_accept(fd: U32): SecureHandler =>
+  SecureHandler(_server_auth, _ssl_ctx, fd, _config)
+
+// In the handler:
+actor SecureHandler is WebSocketServerActor
+  var _ws: WebSocketServer = WebSocketServer.none()
+
+  new create(auth: lori.TCPServerAuth, ssl_ctx: ssl_net.SSLContext val,
+    fd: U32, config: WebSocketConfig val)
+  =>
+    _ws = WebSocketServer.ssl(auth, ssl_ctx, fd, this, config)
+
+  fun ref _websocket(): WebSocketServer => _ws
+```
+
+## Configuration
+
+`WebSocketConfig` controls connection behavior:
+
+- `host` / `port` — bind address (defaults: `"localhost"` / `"8080"`)
+- `max_message_size` — maximum reassembled message size in bytes
+  (default: 1 MB)
+- `max_handshake_size` — maximum HTTP upgrade request size (default: 8 KB)
+
+## Lifecycle Callbacks
+
+Override any of these on your `WebSocketServerActor`:
+
+- `on_upgrade_request(request)` — inspect the HTTP upgrade before
+  accepting; return `false` to reject with 403
+- `on_open(request)` — connection established
+- `on_text_message(data)` — complete text message received
+- `on_binary_message(data)` — complete binary message received
+- `on_closed()` — connection closed (normal or abnormal)
+- `on_throttled()` / `on_unthrottled()` — backpressure signals
+
+## Sending Messages
+
+Call methods on your `WebSocketServer` instance:
+
+- `send_text(data)` — send a text message
+- `send_binary(data)` — send a binary message
+- `close(code, reason)` — initiate a close handshake
 """


### PR DESCRIPTION
Initial implementation of a WebSocket server library built on [lori](https://github.com/ponylang/lori). Implements RFC 6455 including the HTTP upgrade handshake, frame parsing and encoding, message fragmentation/reassembly, and the close handshake.

Follows lori/stallion's "your actor IS the connection" pattern: users implement `WebSocketServerActor` and the library handles all protocol details, delivering application-level events through lifecycle callbacks.

Architecture:
- `WebSocketServer`: protocol handler class (state machine, parsers, encoder)
- `WebSocketServerActor`: trait combining `TCPConnectionActor` + lifecycle callbacks
- Four-state machine: `_Handshaking` -> `_Open` -> `_Closing` -> `_Closed`
- Internal components: handshake parser, frame parser/encoder, fragment reassembler, UTF-8 validator

60 unit tests including PonyCheck property-based tests for all internal components. WSS (TLS) support via `WebSocketServer.ssl()` constructor.

Design: #2