### PR TITLE
Validate 64-bit payload length MSB per RFC 6455

### DIFF
--- a/websockets/_frame_parser.pony
+++ b/websockets/_frame_parser.pony
@@ -83,6 +83,10 @@ class _FrameParser
       elseif payload_len == 127 then
         header_size = 10
         if _buf.size() < header_size then return None end
+        // RFC 6455 Section 5.2: MSB of 64-bit payload length must be 0
+        if (_buf(2)? and 0x80) != 0 then
+          return _FrameError(CloseProtocolError)
+        end
         payload_len =
           (_buf(2)?.usize() << 56) or
           (_buf(3)?.usize() << 48) or

--- a/websockets/_test.pony
+++ b/websockets/_test.pony
@@ -45,6 +45,7 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[U16](_TestFrameParserCloseMixedCodes))
     test(_TestFrameParserLength16Bit)
     test(_TestFrameParserLength64Bit)
+    test(_TestFrameParserLength64BitMsbSet)
     test(_TestFrameParserUnmasked)
     test(_TestFrameParserNonZeroRsv)
     test(_TestFrameParserFragmentedControl)


### PR DESCRIPTION
Without this check, a client sending a frame with bit 63 set in the 64-bit extended payload length causes the parser to wait for an astronomically large payload that never arrives, stalling the connection until the OS TCP timeout fires (~2 minutes). Now the parser immediately returns a protocol error (1002) close.

Closes #4