### PR TITLE
Validate Host header in handshake per RFC 6455

### DIFF
--- a/websockets/_handshake_parser.pony
+++ b/websockets/_handshake_parser.pony
@@ -98,13 +98,16 @@ class _HandshakeParser
       end
 
       // Validate required WebSocket headers
+      var has_host = false
       var has_upgrade = false
       var has_connection_upgrade = false
       var websocket_key: (String val | None) = None
       var websocket_version: (String val | None) = None
 
       for (name, value) in headers.values() do
-        if name == "upgrade" then
+        if name == "host" then
+          has_host = true
+        elseif name == "upgrade" then
           let value_lower: String val = value.lower()
           if value_lower == "websocket" then
             has_upgrade = true
@@ -126,6 +129,7 @@ class _HandshakeParser
         end
       end
 
+      if not has_host then return HandshakeMissingHost end
       if not has_upgrade then return HandshakeMissingUpgrade end
       if not has_connection_upgrade then return HandshakeMissingUpgrade end
 

--- a/websockets/_test.pony
+++ b/websockets/_test.pony
@@ -60,6 +60,7 @@ actor \nodoc\ Main is TestList
     test(_TestHandshakeRemainingBytes)
     test(_TestHandshakeTooLarge)
     test(_TestHandshakeInvalidMethod)
+    test(_TestHandshakeMissingHost)
     test(_TestHandshakeMissingUpgrade)
     test(_TestHandshakeWrongVersion)
     test(_TestHandshakeMissingKey)

--- a/websockets/_test_handshake_parser.pony
+++ b/websockets/_test_handshake_parser.pony
@@ -119,6 +119,29 @@ class \nodoc\ iso _TestHandshakeInvalidMethod is UnitTest
     | let err: HandshakeError => h.fail("wrong error: " + err.string())
     end
 
+class \nodoc\ iso _TestHandshakeMissingHost is UnitTest
+  """Missing Host header produces HandshakeMissingHost."""
+  fun name(): String => "handshake/missing_host"
+
+  fun apply(h: TestHelper) =>
+    let request: Array[U8] iso = recover iso
+      let s = String(256)
+        .>append("GET / HTTP/1.1\r\n")
+        .>append("Upgrade: websocket\r\n")
+        .>append("Connection: Upgrade\r\n")
+        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+        .>append("Sec-WebSocket-Version: 13\r\n")
+        .>append("\r\n")
+      s.clone().iso_array()
+    end
+    let parser = _HandshakeParser
+    match parser(consume request, 8192)
+    | HandshakeMissingHost => None // expected
+    | _HandshakeNeedMore => h.fail("expected error")
+    | let _: _HandshakeResult => h.fail("expected error")
+    | let err: HandshakeError => h.fail("wrong error: " + err.string())
+    end
+
 class \nodoc\ iso _TestHandshakeMissingUpgrade is UnitTest
   """Missing Upgrade header produces HandshakeMissingUpgrade."""
   fun name(): String => "handshake/missing_upgrade"

--- a/websockets/handshake_error.pony
+++ b/websockets/handshake_error.pony
@@ -2,6 +2,7 @@
 type HandshakeError is
   ( HandshakeRequestTooLarge
   | HandshakeInvalidHTTP
+  | HandshakeMissingHost
   | HandshakeMissingUpgrade
   | HandshakeWrongVersion
   | HandshakeMissingKey )
@@ -15,6 +16,11 @@ primitive HandshakeInvalidHTTP is Stringable
   """The HTTP request line was malformed or not a GET request."""
   fun string(): String iso^ =>
     "Invalid HTTP request".clone()
+
+primitive HandshakeMissingHost is Stringable
+  """The required Host header was missing."""
+  fun string(): String iso^ =>
+    "Missing Host header".clone()
 
 primitive HandshakeMissingUpgrade is Stringable
   """


### PR DESCRIPTION
RFC 6455 Section 4.2.1 requirement 2 mandates a Host header in the HTTP upgrade request. The handshake parser validated the other required headers (Upgrade, Connection, Sec-WebSocket-Version, Sec-WebSocket-Key) but not Host. This adds a presence check and `HandshakeMissingHost` error type, following the existing validation pattern.

Closes #6