### PR TITLE
Validate Sec-WebSocket-Key format in handshake per RFC 6455

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ make build-examples ssl=3.0.x # Just examples
 
 - **lori** (0.8.5) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
 - **ssl** (2.0.0) — SHA-1 digest for computing the WebSocket handshake accept key (`ssl/crypto`). Also provides `ssl/net` for WSS (TLS) support.
-- **stdlib encode/base64** — Base64 encoding for the handshake accept key.
+- **stdlib encode/base64** — Base64 encoding/decoding for the handshake accept key.
 
 Import aliases used consistently across the codebase:
 - `use lori = "lori"`

--- a/websockets/_handshake_parser.pony
+++ b/websockets/_handshake_parser.pony
@@ -141,6 +141,13 @@ class _HandshakeParser
 
       match websocket_key
       | let key: String val =>
+        let decoded_size =
+          try
+            Base64.decode[Array[U8] iso](key)?.size()
+          else
+            return HandshakeInvalidKey
+          end
+        if decoded_size != 16 then return HandshakeInvalidKey end
         let accept_key = _compute_accept_key(key)
 
         // Extract remaining bytes after \r\n\r\n using String

--- a/websockets/_test.pony
+++ b/websockets/_test.pony
@@ -64,11 +64,15 @@ actor \nodoc\ Main is TestList
     test(_TestHandshakeMissingUpgrade)
     test(_TestHandshakeWrongVersion)
     test(_TestHandshakeMissingKey)
+    test(_TestHandshakeInvalidKeyBadBase64)
+    test(_TestHandshakeInvalidKeyWrongLength)
     test(_TestHandshakeCaseInsensitive)
     test(_TestHandshakeIncremental)
     test(_TestHandshakeRfc6455AcceptKey)
     test(_TestHandshakeConnectionMultiToken)
     test(Property1UnitTest[String](_TestHandshakePropertyValidRequests))
+    test(Property1UnitTest[String](_TestHandshakePropertyValidKeys))
+    test(Property1UnitTest[String](_TestHandshakePropertyInvalidKeyLength))
 
     // Fragment reassembler
     test(_TestReassemblerSingleText)

--- a/websockets/handshake_error.pony
+++ b/websockets/handshake_error.pony
@@ -5,7 +5,8 @@ type HandshakeError is
   | HandshakeMissingHost
   | HandshakeMissingUpgrade
   | HandshakeWrongVersion
-  | HandshakeMissingKey )
+  | HandshakeMissingKey
+  | HandshakeInvalidKey )
 
 primitive HandshakeRequestTooLarge is Stringable
   """The HTTP upgrade request exceeded the maximum allowed size."""
@@ -39,3 +40,11 @@ primitive HandshakeMissingKey is Stringable
   """The Sec-WebSocket-Key header was missing."""
   fun string(): String iso^ =>
     "Missing Sec-WebSocket-Key header".clone()
+
+primitive HandshakeInvalidKey is Stringable
+  """
+  The Sec-WebSocket-Key header was not a valid base64-encoded
+  16-byte value.
+  """
+  fun string(): String iso^ =>
+    "Invalid Sec-WebSocket-Key (must be base64-encoded 16 bytes)".clone()


### PR DESCRIPTION
RFC 6455 Section 4.2.1 requirement 5 says `Sec-WebSocket-Key` must be a base64-encoded 16-byte value. The handshake parser previously accepted any non-empty key without validating format.

Now decodes the key with `Base64.decode` and checks the decoded length is exactly 16, returning `HandshakeInvalidKey` on failure. This validates both base64 format and correct length in one step.

Closes #7