### PR TITLE
Pass close code and reason to on_closed() callback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ _Handshaking → _Open → _Closing → _Closed
 | `_frame_parser.pony` | `_FrameParser` | Incremental WebSocket frame parser with masking, length decoding, validation |
 | `_frame_encoder.pony` | `_FrameEncoder` | Builds outgoing server frames (never masked) |
 | `_fragment_reassembler.pony` | `_FragmentReassembler` | Reassembles fragmented messages, enforces size limits, validates UTF-8 for text |
+| `_close_status_extractor.pony` | `_CloseStatusExtractor` | Extracts `(CloseStatus, String val)` from raw close frame payload |
 | `_utf8_validator.pony` | `_Utf8Validator` | UTF-8 byte sequence validation |
 | `_connection_state.pony` | `_ConnectionState` | State machine trait + four state classes |
 | `_mort.pony` | `_Unreachable` | Crash-on-bug helper for impossible code paths |

--- a/examples/echo/main.pony
+++ b/examples/echo/main.pony
@@ -68,5 +68,9 @@ actor EchoHandler is ws.WebSocketServerActor
     _out.print("Binary: " + data.size().string() + " bytes")
     _ws.send_binary(data)
 
-  fun ref on_closed() =>
-    _out.print("Client disconnected")
+  fun ref on_closed(
+    close_status: ws.CloseStatus,
+    close_reason: String val)
+  =>
+    _out.print("Client disconnected: " + close_status.string()
+      + if close_reason.size() > 0 then " (" + close_reason + ")" else "" end)

--- a/websockets/_close_status_extractor.pony
+++ b/websockets/_close_status_extractor.pony
@@ -1,0 +1,65 @@
+primitive _CloseStatusExtractor
+  """
+  Extracts a typed close status and reason string from a raw close frame
+  payload.
+
+  Used in `WebSocketServer` to convert raw frame bytes into the
+  `(CloseStatus, String val)` pair delivered to `on_closed()`.
+  """
+
+  fun from_payload(payload: Array[U8] val): (CloseStatus, String val) =>
+    """
+    Map a close frame payload to a typed status and reason string.
+
+    Empty payloads produce `CloseNoStatusReceived`. Payloads with 2+ bytes
+    have the first two bytes decoded as a big-endian U16 status code and the
+    remainder as the reason string.
+
+    Assumes the payload is either empty or >= 2 bytes — 1-byte close payloads
+    are rejected earlier by `_FrameParser`.
+    """
+    if payload.size() == 0 then
+      return (CloseNoStatusReceived, "")
+    end
+
+    try
+      let code = (payload(0)?.u16() << 8) or payload(1)?.u16()
+      let status = _code_to_status(code)
+
+      let reason = if payload.size() > 2 then
+        let s = String(payload.size() - 2)
+        var i: USize = 2
+        while i < payload.size() do
+          s.push(payload(i)?)
+          i = i + 1
+        end
+        s.clone()
+      else
+        ""
+      end
+
+      (status, consume reason)
+    else
+      _Unreachable()
+      (CloseNoStatusReceived, "")
+    end
+
+  fun _code_to_status(code: U16): CloseStatus =>
+    """
+    Map a raw U16 close code to the appropriate `CloseStatus` member.
+
+    Named primitives are returned for standard codes; all others get
+    `OtherCloseCode`.
+    """
+    match code
+    | 1000 => CloseNormal
+    | 1001 => CloseGoingAway
+    | 1002 => CloseProtocolError
+    | 1003 => CloseUnsupportedData
+    | 1007 => CloseInvalidPayload
+    | 1008 => ClosePolicyViolation
+    | 1009 => CloseMessageTooBig
+    | 1011 => CloseInternalError
+    else
+      OtherCloseCode(code)
+    end

--- a/websockets/_connection_state.pony
+++ b/websockets/_connection_state.pony
@@ -73,7 +73,7 @@ primitive _Open is _ConnectionState
 
   fun on_closed(server: WebSocketServer ref) =>
     // Abnormal TCP close
-    server._fire_on_closed()
+    server._fire_on_closed(CloseAbnormalClosure, "")
     server._set_state(_Closed)
 
   fun on_throttled(server: WebSocketServer ref) =>
@@ -112,7 +112,7 @@ primitive _Closing is _ConnectionState
 
   fun on_closed(server: WebSocketServer ref) =>
     // TCP dropped before close response
-    server._fire_on_closed()
+    server._fire_on_closed(CloseAbnormalClosure, "")
     server._set_state(_Closed)
 
   fun on_throttled(server: WebSocketServer ref) => None

--- a/websockets/_frame_parser.pony
+++ b/websockets/_frame_parser.pony
@@ -130,6 +130,9 @@ class _FrameParser
 
       // Validate close frame payload
       if opcode == 0x08 then
+        // Coupling: _CloseStatusExtractor.from_payload assumes close payloads
+        // are either empty or >= 2 bytes. Removing this check would cause the
+        // extractor to mishandle 1-byte payloads.
         if payload.size() == 1 then
           return _FrameError(CloseProtocolError)
         end
@@ -184,6 +187,9 @@ class _FrameParser
 
   fun _valid_close_code(code: U16): Bool =>
     """Check if a close status code is valid to receive per RFC 6455."""
+    // Coupling: _CloseStatusExtractor._code_to_status must stay in sync with
+    // these valid code ranges. Adding new ranges here means adding
+    // corresponding match arms in the extractor.
     if (code >= 1000) and (code <= 1003) then true
     elseif (code >= 1007) and (code <= 1014) then true
     elseif (code >= 3000) and (code <= 4999) then true

--- a/websockets/_test.pony
+++ b/websockets/_test.pony
@@ -74,6 +74,19 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[String](_TestHandshakePropertyValidKeys))
     test(Property1UnitTest[String](_TestHandshakePropertyInvalidKeyLength))
 
+    // Close status extractor
+    test(_TestExtractorEmptyPayload)
+    test(_TestExtractorStandardCode)
+    test(_TestExtractorCodeWithReason)
+    test(_TestExtractorApplicationCode)
+    test(_TestExtractorAllNamedCodes)
+    test(_TestCloseNoStatusReceivedType)
+    test(_TestCloseAbnormalClosureType)
+    test(_TestOtherCloseCodeType)
+    test(Property1UnitTest[U16](_TestExtractorPropertyNamedCodes))
+    test(Property1UnitTest[U16](_TestExtractorPropertyOtherCodes))
+    test(Property1UnitTest[U16](_TestExtractorPropertyRoundtrip))
+
     // Fragment reassembler
     test(_TestReassemblerSingleText)
     test(_TestReassemblerSingleBinary)

--- a/websockets/_test_close_status.pony
+++ b/websockets/_test_close_status.pony
@@ -1,0 +1,186 @@
+use "pony_test"
+use "pony_check"
+
+// -- Example-based tests for _CloseStatusExtractor --
+
+class \nodoc\ _TestExtractorEmptyPayload is UnitTest
+  fun name(): String => "CloseStatusExtractor/empty payload"
+
+  fun apply(h: TestHelper) =>
+    (let status, let reason) =
+      _CloseStatusExtractor.from_payload(recover val Array[U8] end)
+    h.assert_is[CloseStatus](CloseNoStatusReceived, status)
+    h.assert_eq[String val]("", reason)
+
+class \nodoc\ _TestExtractorStandardCode is UnitTest
+  fun name(): String => "CloseStatusExtractor/standard code 1000"
+
+  fun apply(h: TestHelper) =>
+    let payload: Array[U8] val = recover val [as U8: 0x03; 0xE8] end
+    (let status, let reason) = _CloseStatusExtractor.from_payload(payload)
+    h.assert_is[CloseStatus](CloseNormal, status)
+    h.assert_eq[String val]("", reason)
+
+class \nodoc\ _TestExtractorCodeWithReason is UnitTest
+  fun name(): String => "CloseStatusExtractor/code with reason"
+
+  fun apply(h: TestHelper) =>
+    // 1000 + "bye"
+    let payload: Array[U8] val =
+      recover val [as U8: 0x03; 0xE8; 'b'; 'y'; 'e'] end
+    (let status, let reason) = _CloseStatusExtractor.from_payload(payload)
+    h.assert_is[CloseStatus](CloseNormal, status)
+    h.assert_eq[String val]("bye", reason)
+
+class \nodoc\ _TestExtractorApplicationCode is UnitTest
+  fun name(): String => "CloseStatusExtractor/application code 3000"
+
+  fun apply(h: TestHelper) =>
+    // 3000 = 0x0BB8
+    let payload: Array[U8] val = recover val [as U8: 0x0B; 0xB8] end
+    (let status, let reason) = _CloseStatusExtractor.from_payload(payload)
+    match status
+    | let o: OtherCloseCode =>
+      h.assert_eq[U16](3000, o.code())
+    else
+      h.fail("Expected OtherCloseCode, got named primitive")
+    end
+    h.assert_eq[String val]("", reason)
+
+class \nodoc\ _TestExtractorAllNamedCodes is UnitTest
+  fun name(): String => "CloseStatusExtractor/all named codes"
+
+  fun apply(h: TestHelper) =>
+    _check(h, 1000, CloseNormal)
+    _check(h, 1001, CloseGoingAway)
+    _check(h, 1002, CloseProtocolError)
+    _check(h, 1003, CloseUnsupportedData)
+    _check(h, 1007, CloseInvalidPayload)
+    _check(h, 1008, ClosePolicyViolation)
+    _check(h, 1009, CloseMessageTooBig)
+    _check(h, 1011, CloseInternalError)
+
+  fun _check(h: TestHelper, code: U16, expected: CloseStatus) =>
+    let payload: Array[U8] val = recover val
+      [as U8: (code >> 8).u8(); code.u8()]
+    end
+    (let status, _) = _CloseStatusExtractor.from_payload(payload)
+    h.assert_is[CloseStatus](expected, status)
+
+// -- Example-based tests for new types --
+
+class \nodoc\ _TestCloseNoStatusReceivedType is UnitTest
+  fun name(): String => "CloseNoStatusReceived/code and string"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[U16](1005, CloseNoStatusReceived.code())
+    h.assert_eq[String val]("1005 No Status Received",
+      CloseNoStatusReceived.string())
+
+class \nodoc\ _TestCloseAbnormalClosureType is UnitTest
+  fun name(): String => "CloseAbnormalClosure/code and string"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[U16](1006, CloseAbnormalClosure.code())
+    h.assert_eq[String val]("1006 Abnormal Closure",
+      CloseAbnormalClosure.string())
+
+class \nodoc\ _TestOtherCloseCodeType is UnitTest
+  fun name(): String => "OtherCloseCode/code and string"
+
+  fun apply(h: TestHelper) =>
+    let c = OtherCloseCode(3500)
+    h.assert_eq[U16](3500, c.code())
+    h.assert_eq[String val]("3500 Other", c.string())
+
+// -- Property-based tests --
+
+class \nodoc\ _TestExtractorPropertyNamedCodes is Property1[U16]
+  """All named code values produce their respective primitive."""
+
+  fun name(): String => "CloseStatusExtractor/property: named codes"
+
+  fun gen(): Generator[U16] =>
+    Generators.one_of[U16]([as U16: 1000; 1001; 1002; 1003
+      1007; 1008; 1009; 1011])
+
+  fun property(sample: U16, h: PropertyHelper) =>
+    let payload: Array[U8] val = recover val
+      [as U8: (sample >> 8).u8(); sample.u8()]
+    end
+    (let status, _) = _CloseStatusExtractor.from_payload(payload)
+    match status
+    | let _: OtherCloseCode =>
+      h.fail("Named code " + sample.string() + " produced OtherCloseCode")
+    end
+    // Verify the code() method returns the input
+    match status
+    | let s: CloseNormal => h.assert_eq[U16](sample, s.code())
+    | let s: CloseGoingAway => h.assert_eq[U16](sample, s.code())
+    | let s: CloseProtocolError => h.assert_eq[U16](sample, s.code())
+    | let s: CloseUnsupportedData => h.assert_eq[U16](sample, s.code())
+    | let s: CloseInvalidPayload => h.assert_eq[U16](sample, s.code())
+    | let s: ClosePolicyViolation => h.assert_eq[U16](sample, s.code())
+    | let s: CloseMessageTooBig => h.assert_eq[U16](sample, s.code())
+    | let s: CloseInternalError => h.assert_eq[U16](sample, s.code())
+    end
+
+class \nodoc\ _TestExtractorPropertyOtherCodes is Property1[U16]
+  """Valid-but-unnamed codes produce OtherCloseCode with matching code()."""
+
+  fun name(): String => "CloseStatusExtractor/property: other codes"
+
+  fun gen(): Generator[U16] =>
+    // Valid codes that don't have named primitives:
+    // 1010, 1012-1014, 3000-4999
+    Generators.frequency[U16]([as (USize, Generator[U16]):
+      (1, Generators.one_of[U16]([as U16: 1010; 1012; 1013; 1014]))
+      (4, Generators.u16(3000, 4999))
+    ])
+
+  fun property(sample: U16, h: PropertyHelper) =>
+    let payload: Array[U8] val = recover val
+      [as U8: (sample >> 8).u8(); sample.u8()]
+    end
+    (let status, _) = _CloseStatusExtractor.from_payload(payload)
+    match status
+    | let o: OtherCloseCode =>
+      h.assert_eq[U16](sample, o.code())
+    else
+      h.fail("Code " + sample.string()
+        + " should produce OtherCloseCode but got named primitive")
+    end
+
+class \nodoc\ _TestExtractorPropertyRoundtrip is Property1[U16]
+  """All valid close codes roundtrip through extraction."""
+
+  fun name(): String => "CloseStatusExtractor/property: roundtrip"
+
+  fun gen(): Generator[U16] =>
+    // All valid receivable codes: 1000-1003, 1007-1014, 3000-4999
+    Generators.frequency[U16]([as (USize, Generator[U16]):
+      (1, Generators.u16(1000, 1003))
+      (1, Generators.u16(1007, 1014))
+      (4, Generators.u16(3000, 4999))
+    ])
+
+  fun property(sample: U16, h: PropertyHelper) =>
+    let payload: Array[U8] val = recover val
+      [as U8: (sample >> 8).u8(); sample.u8()]
+    end
+    (let status, _) = _CloseStatusExtractor.from_payload(payload)
+    // Verify the extracted code matches the input regardless of type
+    let extracted_code = match status
+      | let s: CloseNormal => s.code()
+      | let s: CloseGoingAway => s.code()
+      | let s: CloseProtocolError => s.code()
+      | let s: CloseUnsupportedData => s.code()
+      | let s: CloseInvalidPayload => s.code()
+      | let s: ClosePolicyViolation => s.code()
+      | let s: CloseMessageTooBig => s.code()
+      | let s: CloseInternalError => s.code()
+      | let s: CloseNoStatusReceived => s.code()
+      | let s: CloseAbnormalClosure => s.code()
+      | let s: OtherCloseCode => s.code()
+      end
+    h.assert_eq[U16](sample, extracted_code)

--- a/websockets/close_status.pony
+++ b/websockets/close_status.pony
@@ -1,0 +1,48 @@
+// CloseStatus covers all close status codes that can be reported to the
+// application via the on_closed() callback. This is a superset of CloseCode
+// (the send API type) — it adds indicator codes (1005, 1006) and
+// OtherCloseCode for valid codes without named primitives.
+type CloseStatus is
+  ( CloseCode
+  | CloseNoStatusReceived
+  | CloseAbnormalClosure
+  | OtherCloseCode )
+
+primitive CloseNoStatusReceived is Stringable
+  """
+  No status received (1005).
+
+  Indicates the close frame had no payload. This is an indicator code that
+  must never appear on the wire — it exists only for the application callback.
+  """
+  fun code(): U16 => 1005
+  fun string(): String iso^ => "1005 No Status Received".clone()
+
+primitive CloseAbnormalClosure is Stringable
+  """
+  Abnormal closure (1006).
+
+  Indicates the TCP connection dropped without a close handshake. This is an
+  indicator code that must never appear on the wire — it exists only for the
+  application callback.
+  """
+  fun code(): U16 => 1006
+  fun string(): String iso^ => "1006 Abnormal Closure".clone()
+
+class val OtherCloseCode is Stringable
+  """
+  A valid close status code without a named primitive.
+
+  Covers application-defined codes (3000-4999), IANA-registered codes without
+  named primitives (1010, 1012-1014), and any future additions to the
+  standard range. The raw code is preserved for application inspection.
+  """
+  let _code: U16
+
+  new val create(code': U16) =>
+    _code = code'
+
+  fun code(): U16 => _code
+
+  fun string(): String iso^ =>
+    (_code.string() + " Other").clone()

--- a/websockets/websocket_lifecycle_event_receiver.pony
+++ b/websockets/websocket_lifecycle_event_receiver.pony
@@ -40,8 +40,22 @@ trait WebSocketLifecycleEventReceiver
     """Called when a complete binary message is received."""
     None
 
-  fun ref on_closed() =>
-    """Called when the WebSocket connection closes."""
+  fun ref on_closed(
+    close_status: CloseStatus,
+    close_reason: String val)
+  =>
+    """
+    Called when the WebSocket connection closes.
+
+    `close_status` indicates why the connection closed — a named primitive
+    for standard codes (e.g., `CloseNormal`), `CloseNoStatusReceived` when
+    the close frame had no payload, `CloseAbnormalClosure` when TCP dropped
+    without a close handshake, or `OtherCloseCode` for application-defined
+    or IANA-registered codes without named primitives.
+
+    `close_reason` is the UTF-8 reason string from the close frame, or
+    empty when no reason was provided or the close was abnormal.
+    """
     None
 
   fun ref on_throttled() =>

--- a/websockets/websockets.pony
+++ b/websockets/websockets.pony
@@ -108,7 +108,9 @@ Override any of these on your `WebSocketServerActor`:
 - `on_open(request)` — connection established
 - `on_text_message(data)` — complete text message received
 - `on_binary_message(data)` — complete binary message received
-- `on_closed()` — connection closed (normal or abnormal)
+- `on_closed(close_status, close_reason)` — connection closed; `close_status`
+  is a `CloseStatus` indicating why (e.g., `CloseNormal`, `CloseAbnormalClosure`),
+  `close_reason` is the UTF-8 reason string from the close frame (or empty)
 - `on_throttled()` / `on_unthrottled()` — backpressure signals
 
 ## Sending Messages


### PR DESCRIPTION
The `on_closed()` callback took no parameters, so applications had no way to know why a connection closed — whether it was a normal closure, a protocol error, or a TCP drop. The close frame payload contains a status code and optional reason string, but they were discarded before reaching the application layer.

Changes:

- Add `CloseStatus` union type (superset of `CloseCode`) covering all reportable close scenarios: the 8 named server-sendable codes, indicator codes (1005 No Status Received, 1006 Abnormal Closure), and `OtherCloseCode` for valid codes without named primitives (1010, 1012-1014, 3000-4999)
- Add `_CloseStatusExtractor` to map raw close frame payloads to typed `(CloseStatus, String val)` pairs
- Change `on_closed()` to `on_closed(close_status: CloseStatus, close_reason: String val)`
- Update all 7 close paths (2 TCP drops, 2 close frame receives, 3 error paths) to pass the appropriate status
- Add coupling comments on `_FrameParser` documenting dependencies with the extractor

The send API (`close()`) still takes `CloseCode`, preventing indicator codes from being sent on the wire.

Closes #9