### PR TITLE
Add docstrings to public methods on close code and error types

### DIFF
--- a/mare/close_code.pony
+++ b/mare/close_code.pony
@@ -11,40 +11,72 @@ type CloseCode is
 
 primitive CloseNormal is Stringable
   """Normal closure (1000). The connection fulfilled its purpose."""
-  fun code(): U16 => 1000
-  fun string(): String iso^ => "1000 Normal Closure".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1000
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1000 Normal Closure".clone()
 
 primitive CloseGoingAway is Stringable
   """Going away (1001). The endpoint is shutting down."""
-  fun code(): U16 => 1001
-  fun string(): String iso^ => "1001 Going Away".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1001
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1001 Going Away".clone()
 
 primitive CloseProtocolError is Stringable
   """Protocol error (1002). A protocol violation was detected."""
-  fun code(): U16 => 1002
-  fun string(): String iso^ => "1002 Protocol Error".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1002
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1002 Protocol Error".clone()
 
 primitive CloseUnsupportedData is Stringable
   """Unsupported data (1003). An unsupported data type was received."""
-  fun code(): U16 => 1003
-  fun string(): String iso^ => "1003 Unsupported Data".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1003
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1003 Unsupported Data".clone()
 
 primitive CloseInvalidPayload is Stringable
   """Invalid payload (1007). A message payload was not valid."""
-  fun code(): U16 => 1007
-  fun string(): String iso^ => "1007 Invalid Payload".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1007
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1007 Invalid Payload".clone()
 
 primitive ClosePolicyViolation is Stringable
   """Policy violation (1008). A policy was violated."""
-  fun code(): U16 => 1008
-  fun string(): String iso^ => "1008 Policy Violation".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1008
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1008 Policy Violation".clone()
 
 primitive CloseMessageTooBig is Stringable
   """Message too big (1009). A message exceeded the size limit."""
-  fun code(): U16 => 1009
-  fun string(): String iso^ => "1009 Message Too Big".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1009
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1009 Message Too Big".clone()
 
 primitive CloseInternalError is Stringable
   """Internal error (1011). An unexpected server error occurred."""
-  fun code(): U16 => 1011
-  fun string(): String iso^ => "1011 Internal Error".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1011
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1011 Internal Error".clone()

--- a/mare/close_status.pony
+++ b/mare/close_status.pony
@@ -15,8 +15,12 @@ primitive CloseNoStatusReceived is Stringable
   Indicates the close frame had no payload. This is an indicator code that
   must never appear on the wire — it exists only for the application callback.
   """
-  fun code(): U16 => 1005
-  fun string(): String iso^ => "1005 No Status Received".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1005
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1005 No Status Received".clone()
 
 primitive CloseAbnormalClosure is Stringable
   """
@@ -26,8 +30,12 @@ primitive CloseAbnormalClosure is Stringable
   indicator code that must never appear on the wire — it exists only for the
   application callback.
   """
-  fun code(): U16 => 1006
-  fun string(): String iso^ => "1006 Abnormal Closure".clone()
+  fun code(): U16 =>
+    """Returns the RFC 6455 numeric close code."""
+    1006
+  fun string(): String iso^ =>
+    """Returns a human-readable representation including the code and name."""
+    "1006 Abnormal Closure".clone()
 
 class val OtherCloseCode is Stringable
   """
@@ -40,9 +48,13 @@ class val OtherCloseCode is Stringable
   let _code: U16
 
   new val create(code': U16) =>
+    """Create an OtherCloseCode wrapping the given numeric code."""
     _code = code'
 
-  fun code(): U16 => _code
+  fun code(): U16 =>
+    """Returns the raw numeric close code."""
+    _code
 
   fun string(): String iso^ =>
+    """Returns a human-readable representation including the numeric code."""
     (_code.string() + " Other").clone()

--- a/mare/handshake_error.pony
+++ b/mare/handshake_error.pony
@@ -11,16 +11,19 @@ type HandshakeError is
 primitive HandshakeRequestTooLarge is Stringable
   """The HTTP upgrade request exceeded the maximum allowed size."""
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Handshake request too large".clone()
 
 primitive HandshakeInvalidHTTP is Stringable
   """The HTTP request line was malformed or not a GET request."""
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Invalid HTTP request".clone()
 
 primitive HandshakeMissingHost is Stringable
   """The required Host header was missing."""
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Missing Host header".clone()
 
 primitive HandshakeMissingUpgrade is Stringable
@@ -29,16 +32,19 @@ primitive HandshakeMissingUpgrade is Stringable
   incorrect values.
   """
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Missing or invalid Upgrade/Connection headers".clone()
 
 primitive HandshakeWrongVersion is Stringable
   """The Sec-WebSocket-Version header was not 13."""
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Wrong WebSocket version (expected 13)".clone()
 
 primitive HandshakeMissingKey is Stringable
   """The Sec-WebSocket-Key header was missing."""
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Missing Sec-WebSocket-Key header".clone()
 
 primitive HandshakeInvalidKey is Stringable
@@ -47,4 +53,5 @@ primitive HandshakeInvalidKey is Stringable
   16-byte value.
   """
   fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
     "Invalid Sec-WebSocket-Key (must be base64-encoded 16 bytes)".clone()


### PR DESCRIPTION
Generated API docs were missing per-method documentation for `code()`, `string()`, and `create()` on `CloseCode`/`CloseStatus` primitives, `OtherCloseCode`, and `HandshakeError` primitives. All public API methods now have docstrings so the generated docs site has complete coverage.