### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/examples/close-codes/main.pony
+++ b/examples/close-codes/main.pony
@@ -86,7 +86,7 @@ actor CloseHandler is ws.WebSocketServerActor
       else ""
       end
 
-    match close_status
+    match \exhaustive\ close_status
     | let c: ws.CloseCode =>
       _out.print("Closed with code: " + c.string() + reason_suffix)
     | let _: ws.CloseNoStatusReceived =>

--- a/examples/request-filter/main.pony
+++ b/examples/request-filter/main.pony
@@ -62,7 +62,7 @@ actor FilterHandler is ws.WebSocketServerActor
   fun ref _websocket(): ws.WebSocketServer => _ws
 
   fun ref on_upgrade_request(request: ws.UpgradeRequest val): Bool =>
-    let origin = match request.header("Origin")
+    let origin = match \exhaustive\ request.header("Origin")
     | let o: String val => o
     | None => ""
     end

--- a/mare/_frame_parser.pony
+++ b/mare/_frame_parser.pony
@@ -21,7 +21,7 @@ class _FrameParser
     let frames = recover iso Array[_ParsedFrame val] end
 
     while _buf.size() > 0 do
-      match _try_parse_frame()
+      match \exhaustive\ _try_parse_frame()
       | let frame: _ParsedFrame val =>
         frames.push(frame)
       | let err: _FrameError =>

--- a/mare/_handshake_parser.pony
+++ b/mare/_handshake_parser.pony
@@ -29,7 +29,7 @@ class _HandshakeParser
       return HandshakeRequestTooLarge
     end
 
-    match _find_header_end()
+    match \exhaustive\ _find_header_end()
     | None => _HandshakeNeedMore
     | let pos: USize => _parse_request(pos)
     end
@@ -133,13 +133,13 @@ class _HandshakeParser
       if not has_upgrade then return HandshakeMissingUpgrade end
       if not has_connection_upgrade then return HandshakeMissingUpgrade end
 
-      match websocket_version
+      match \exhaustive\ websocket_version
       | let v: String val =>
         if v != "13" then return HandshakeWrongVersion end
       | None => return HandshakeWrongVersion
       end
 
-      match websocket_key
+      match \exhaustive\ websocket_key
       | let key: String val =>
         let decoded_size =
           try

--- a/mare/_test_close_status.pony
+++ b/mare/_test_close_status.pony
@@ -170,7 +170,7 @@ class \nodoc\ _TestExtractorPropertyRoundtrip is Property1[U16]
     end
     (let status, _) = _CloseStatusExtractor.from_payload(payload)
     // Verify the extracted code matches the input regardless of type
-    let extracted_code = match status
+    let extracted_code = match \exhaustive\ status
       | let s: CloseNormal => s.code()
       | let s: CloseGoingAway => s.code()
       | let s: CloseProtocolError => s.code()

--- a/mare/_test_fragment_reassembler.pony
+++ b/mare/_test_fragment_reassembler.pony
@@ -8,7 +8,7 @@ class \nodoc\ iso _TestReassemblerSingleText is UnitTest
   fun apply(h: TestHelper) =>
     let reassembler = _FragmentReassembler
     let payload: Array[U8] val = "Hello".array()
-    match reassembler.frame(true, 0x01, payload, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x01, payload, 1_048_576)
     | let msg: _CompleteMessage =>
       h.assert_true(msg.is_text)
       h.assert_eq[USize](5, msg.data.size())
@@ -23,7 +23,7 @@ class \nodoc\ iso _TestReassemblerSingleBinary is UnitTest
   fun apply(h: TestHelper) =>
     let reassembler = _FragmentReassembler
     let payload: Array[U8] val = recover val [as U8: 0x01; 0x02] end
-    match reassembler.frame(true, 0x02, payload, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x02, payload, 1_048_576)
     | let msg: _CompleteMessage =>
       h.assert_false(msg.is_text)
       h.assert_eq[USize](2, msg.data.size())
@@ -40,7 +40,7 @@ class \nodoc\ iso _TestReassemblerMultiFragment is UnitTest
 
     // First fragment: text, FIN=0
     let frag1: Array[U8] val = "Hel".array()
-    match reassembler.frame(false, 0x01, frag1, 1_048_576)
+    match \exhaustive\ reassembler.frame(false, 0x01, frag1, 1_048_576)
     | _FragmentContinue => None // expected
     | let _: _CompleteMessage => h.fail("too early")
     | let err: _ReassemblyError => h.fail("unexpected error")
@@ -48,7 +48,7 @@ class \nodoc\ iso _TestReassemblerMultiFragment is UnitTest
 
     // Continuation: FIN=0
     let frag2: Array[U8] val = "lo ".array()
-    match reassembler.frame(false, 0x00, frag2, 1_048_576)
+    match \exhaustive\ reassembler.frame(false, 0x00, frag2, 1_048_576)
     | _FragmentContinue => None // expected
     | let _: _CompleteMessage => h.fail("too early")
     | let err: _ReassemblyError => h.fail("unexpected error")
@@ -56,7 +56,7 @@ class \nodoc\ iso _TestReassemblerMultiFragment is UnitTest
 
     // Final continuation: FIN=1
     let frag3: Array[U8] val = "World".array()
-    match reassembler.frame(true, 0x00, frag3, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x00, frag3, 1_048_576)
     | let msg: _CompleteMessage =>
       h.assert_true(msg.is_text)
       h.assert_eq[USize](11, msg.data.size())
@@ -83,7 +83,7 @@ class \nodoc\ iso _TestReassemblerInterleavedData is UnitTest
 
     // Attempt to start a new text message (interleaved)
     let frag2: Array[U8] val = "World".array()
-    match reassembler.frame(true, 0x01, frag2, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x01, frag2, 1_048_576)
     | let err: _ReassemblyError =>
       h.assert_is[CloseCode](CloseProtocolError, err.code)
     | _FragmentContinue => h.fail("expected error")
@@ -102,7 +102,7 @@ class \nodoc\ iso _TestReassemblerMaxSize is UnitTest
       while i < 100 do a.push(0x41); i = i + 1 end
       a
     end
-    match reassembler.frame(true, 0x02, payload, 50) // max=50
+    match \exhaustive\ reassembler.frame(true, 0x02, payload, 50) // max=50
     | let err: _ReassemblyError =>
       h.assert_is[CloseCode](CloseMessageTooBig, err.code)
     | _FragmentContinue => h.fail("expected error")
@@ -116,7 +116,7 @@ class \nodoc\ iso _TestReassemblerInvalidUtf8 is UnitTest
   fun apply(h: TestHelper) =>
     let reassembler = _FragmentReassembler
     let payload: Array[U8] val = recover val [as U8: 0xFF; 0xFE] end
-    match reassembler.frame(true, 0x01, payload, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x01, payload, 1_048_576)
     | let err: _ReassemblyError =>
       h.assert_is[CloseCode](CloseInvalidPayload, err.code)
     | _FragmentContinue => h.fail("expected error")
@@ -132,7 +132,7 @@ class \nodoc\ iso _TestReassemblerValidUtf8 is UnitTest
     // Valid UTF-8: "café" = 63 61 66 C3 A9
     let payload: Array[U8] val =
       recover val [as U8: 0x63; 0x61; 0x66; 0xC3; 0xA9] end
-    match reassembler.frame(true, 0x01, payload, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x01, payload, 1_048_576)
     | let msg: _CompleteMessage =>
       h.assert_true(msg.is_text)
       h.assert_eq[USize](5, msg.data.size())
@@ -147,7 +147,7 @@ class \nodoc\ iso _TestReassemblerContinuationWithoutStart is UnitTest
   fun apply(h: TestHelper) =>
     let reassembler = _FragmentReassembler
     let payload: Array[U8] val = "data".array()
-    match reassembler.frame(true, 0x00, payload, 1_048_576)
+    match \exhaustive\ reassembler.frame(true, 0x00, payload, 1_048_576)
     | let err: _ReassemblyError =>
       h.assert_is[CloseCode](CloseProtocolError, err.code)
     | _FragmentContinue => h.fail("expected error")
@@ -197,15 +197,15 @@ class \nodoc\ iso _TestReassemblerPropertyRoundtrip is Property1[USize]
     end
 
     let reassembler = _FragmentReassembler
-    match reassembler.frame(false, 0x02, frag1, total_size + 1)
+    match \exhaustive\ reassembler.frame(false, 0x02, frag1, total_size + 1)
     | _FragmentContinue => None
     else h.fail("expected continue for frag1")
     end
-    match reassembler.frame(false, 0x00, frag2, total_size + 1)
+    match \exhaustive\ reassembler.frame(false, 0x00, frag2, total_size + 1)
     | _FragmentContinue => None
     else h.fail("expected continue for frag2")
     end
-    match reassembler.frame(true, 0x00, frag3, total_size + 1)
+    match \exhaustive\ reassembler.frame(true, 0x00, frag3, total_size + 1)
     | let msg: _CompleteMessage =>
       h.assert_false(msg.is_text)
       h.assert_eq[USize](total_size, msg.data.size())

--- a/mare/_test_frame_encoder.pony
+++ b/mare/_test_frame_encoder.pony
@@ -158,7 +158,7 @@ class \nodoc\ iso _TestFrameEncoderPropertyRoundtrip is Property1[USize]
 
     // Parse
     let parser = _FrameParser
-    match parser.parse(masked)
+    match \exhaustive\ parser.parse(masked)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       let parsed = frames(0)?

--- a/mare/_test_frame_parser.pony
+++ b/mare/_test_frame_parser.pony
@@ -102,7 +102,7 @@ class \nodoc\ iso _TestFrameParserText is UnitTest
     let frame = _TestFrameHelper.masked_frame(
       true, 0x01, "Hello".array())
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_true(frames(0)?.fin)
@@ -120,7 +120,7 @@ class \nodoc\ iso _TestFrameParserBinary is UnitTest
     let payload: Array[U8] val = recover val [as U8: 0x01; 0x02; 0x03] end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x02, frames(0)?.opcode)
@@ -138,7 +138,7 @@ class \nodoc\ iso _TestFrameParserPing is UnitTest
     let payload: Array[U8] val = recover val [as U8: 0xAA; 0xBB] end
     let frame = _TestFrameHelper.masked_frame(true, 0x09, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x09, frames(0)?.opcode)
@@ -154,7 +154,7 @@ class \nodoc\ iso _TestFrameParserPong is UnitTest
     let frame = _TestFrameHelper.masked_frame(
       true, 0x0A, recover val Array[U8] end)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x0A, frames(0)?.opcode)
@@ -171,7 +171,7 @@ class \nodoc\ iso _TestFrameParserCloseWithCode is UnitTest
       recover val [as U8: 0x03; 0xE8; 'b'; 'y'; 'e'] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x08, frames(0)?.opcode)
@@ -190,7 +190,7 @@ class \nodoc\ iso _TestFrameParserCloseEmpty is UnitTest
     let frame = _TestFrameHelper.masked_frame(
       true, 0x08, recover val Array[U8] end)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x08, frames(0)?.opcode)
@@ -206,7 +206,7 @@ class \nodoc\ iso _TestFrameParserCloseOneByte is UnitTest
     let payload: Array[U8] val = recover val [as U8: 0x03] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for 1-byte close payload")
     | let err: _FrameError =>
@@ -223,7 +223,7 @@ class \nodoc\ iso _TestFrameParserCloseInvalidUtf8Reason is UnitTest
       recover val [as U8: 0x03; 0xE8; 0xFF] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for invalid UTF-8 in close reason")
     | let err: _FrameError =>
@@ -240,7 +240,7 @@ class \nodoc\ iso _TestFrameParserCloseValidUtf8Reason is UnitTest
       recover val [as U8: 0x03; 0xE8; 'O'; 'K'] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x08, frames(0)?.opcode)
@@ -260,7 +260,7 @@ class \nodoc\ iso _TestFrameParserLength16Bit is UnitTest
     end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[USize](200, frames(0)?.payload.size())
@@ -281,7 +281,7 @@ class \nodoc\ iso _TestFrameParserLength64Bit is UnitTest
     end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[USize](size, frames(0)?.payload.size())
@@ -309,7 +309,7 @@ class \nodoc\ iso _TestFrameParserLength64BitMsbSet is UnitTest
       f
     end
     let parser = _FrameParser
-    match parser.parse(raw)
+    match \exhaustive\ parser.parse(raw)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for 64-bit length with MSB set")
     | let err: _FrameError =>
@@ -324,7 +324,7 @@ class \nodoc\ iso _TestFrameParserUnmasked is UnitTest
     let frame = _TestFrameHelper.unmasked_frame(
       true, 0x01, "Hello".array())
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for unmasked frame")
     | let err: _FrameError =>
@@ -345,7 +345,7 @@ class \nodoc\ iso _TestFrameParserNonZeroRsv is UnitTest
       f
     end
     let parser = _FrameParser
-    match parser.parse(raw)
+    match \exhaustive\ parser.parse(raw)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for RSV bits")
     | let err: _FrameError =>
@@ -360,7 +360,7 @@ class \nodoc\ iso _TestFrameParserFragmentedControl is UnitTest
     let frame = _TestFrameHelper.masked_frame(
       false, 0x09, recover val Array[U8] end)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for fragmented control frame")
     | let err: _FrameError =>
@@ -380,7 +380,7 @@ class \nodoc\ iso _TestFrameParserControlTooLarge is UnitTest
     end
     let frame = _TestFrameHelper.masked_frame(true, 0x09, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for oversized control frame")
     | let err: _FrameError =>
@@ -395,7 +395,7 @@ class \nodoc\ iso _TestFrameParserUnknownOpcode is UnitTest
     let frame = _TestFrameHelper.masked_frame(
       true, 0x03, recover val Array[U8] end)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for unknown opcode")
     | let err: _FrameError =>
@@ -415,7 +415,7 @@ class \nodoc\ iso _TestFrameParserIncremental is UnitTest
     var i: USize = 0
     while i < (full_frame.size() - 1) do
       let byte: Array[U8] val = recover val [as U8: full_frame(i)?] end
-      match parser.parse(byte)
+      match \exhaustive\ parser.parse(byte)
       | let frames: Array[_ParsedFrame val] val =>
         h.assert_eq[USize](0, frames.size())
       | let err: _FrameError => h.fail("unexpected error at byte " +
@@ -426,7 +426,7 @@ class \nodoc\ iso _TestFrameParserIncremental is UnitTest
 
     // Feed last byte — should complete the frame
     let last: Array[U8] val = recover val [as U8: full_frame(i)?] end
-    match parser.parse(last)
+    match \exhaustive\ parser.parse(last)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x01, frames(0)?.opcode)
@@ -454,7 +454,7 @@ class \nodoc\ iso _TestFrameParserMultipleFrames is UnitTest
     end
 
     let parser = _FrameParser
-    match parser.parse(combined)
+    match \exhaustive\ parser.parse(combined)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](2, frames.size())
       h.assert_eq[U8](0x01, frames(0)?.opcode)
@@ -479,7 +479,7 @@ class \nodoc\ iso _TestFrameParserCloseValidCodes is Property1[U16]
       recover val [as U8: (code >> 8).u8(); code.u8()] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x08, frames(0)?.opcode)
@@ -507,7 +507,7 @@ class \nodoc\ iso _TestFrameParserCloseInvalidCodes is Property1[U16]
       recover val [as U8: (code >> 8).u8(); code.u8()] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.fail("expected error for invalid code " + code.string())
     | let err: _FrameError =>
@@ -543,7 +543,7 @@ class \nodoc\ iso _TestFrameParserCloseMixedCodes is Property1[U16]
       recover val [as U8: (code >> 8).u8(); code.u8()] end
     let frame = _TestFrameHelper.masked_frame(true, 0x08, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_true(valid, "code " + code.string() + " should be rejected")
     | let err: _FrameError =>
@@ -566,7 +566,7 @@ class \nodoc\ iso _TestFrameParserPropertyRandom is Property1[USize]
     end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
-    match parser.parse(frame)
+    match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
       h.assert_eq[USize](1, frames.size())
       h.assert_eq[U8](0x02, frames(0)?.opcode)

--- a/mare/_test_handshake_parser.pony
+++ b/mare/_test_handshake_parser.pony
@@ -43,7 +43,7 @@ class \nodoc\ iso _TestHandshakeValid is UnitTest
   fun apply(h: TestHelper) =>
     let parser = _HandshakeParser
     let data = _TestHandshakeHelper.valid_request()
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String]("/", result.request.uri)
       let expected_key =
@@ -72,7 +72,7 @@ class \nodoc\ iso _TestHandshakeRemainingBytes is UnitTest
       c
     end
     let parser = _HandshakeParser
-    match parser(consume combined, 8192)
+    match \exhaustive\ parser(consume combined, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[USize](2, result.remaining.size())
       h.assert_eq[U8](0x81, result.remaining(0)?)
@@ -88,7 +88,7 @@ class \nodoc\ iso _TestHandshakeTooLarge is UnitTest
   fun apply(h: TestHelper) =>
     let parser = _HandshakeParser
     let data = _TestHandshakeHelper.valid_request()
-    match parser(consume data, 10) // tiny max_size
+    match \exhaustive\ parser(consume data, 10) // tiny max_size
     | HandshakeRequestTooLarge => None // expected
     | _HandshakeNeedMore => h.fail("expected too large error")
     | let _: _HandshakeResult => h.fail("expected too large error")
@@ -112,7 +112,7 @@ class \nodoc\ iso _TestHandshakeInvalidMethod is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | HandshakeInvalidHTTP => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -135,7 +135,7 @@ class \nodoc\ iso _TestHandshakeMissingHost is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | HandshakeMissingHost => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -158,7 +158,7 @@ class \nodoc\ iso _TestHandshakeMissingUpgrade is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | HandshakeMissingUpgrade => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -182,7 +182,7 @@ class \nodoc\ iso _TestHandshakeWrongVersion is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | HandshakeWrongVersion => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -205,7 +205,7 @@ class \nodoc\ iso _TestHandshakeMissingKey is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | HandshakeMissingKey => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -220,7 +220,7 @@ class \nodoc\ iso _TestHandshakeInvalidKeyBadBase64 is UnitTest
     let data = _TestHandshakeHelper.valid_request(
       where key = "!!!invalid-key!!!!!!!!!==")
     let parser = _HandshakeParser
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | HandshakeInvalidKey => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -235,7 +235,7 @@ class \nodoc\ iso _TestHandshakeInvalidKeyWrongLength is UnitTest
     // "dGVzdA==" is base64 for "test" (4 bytes)
     let data = _TestHandshakeHelper.valid_request(where key = "dGVzdA==")
     let parser = _HandshakeParser
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | HandshakeInvalidKey => None // expected
     | _HandshakeNeedMore => h.fail("expected error")
     | let _: _HandshakeResult => h.fail("expected error")
@@ -259,7 +259,7 @@ class \nodoc\ iso _TestHandshakeCaseInsensitive is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String]("/", result.request.uri)
     | _HandshakeNeedMore => h.fail("expected result")
@@ -288,7 +288,7 @@ class \nodoc\ iso _TestHandshakeIncremental is UnitTest
       a
     end
 
-    match parser(consume first_half, 8192)
+    match \exhaustive\ parser(consume first_half, 8192)
     | _HandshakeNeedMore => None // expected
     | let _: _HandshakeResult => h.fail("too early")
     | let err: HandshakeError => h.fail("unexpected error")
@@ -304,7 +304,7 @@ class \nodoc\ iso _TestHandshakeIncremental is UnitTest
       a
     end
 
-    match parser(consume second_half, 8192)
+    match \exhaustive\ parser(consume second_half, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String]("/", result.request.uri)
     | _HandshakeNeedMore => h.fail("expected result after second chunk")
@@ -323,7 +323,7 @@ class \nodoc\ iso _TestHandshakeRfc6455AcceptKey is UnitTest
   fun apply(h: TestHelper) =>
     let parser = _HandshakeParser
     let data = _TestHandshakeHelper.valid_request()
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String]("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", result.accept_key)
     | _HandshakeNeedMore => h.fail("expected result")
@@ -350,7 +350,7 @@ class \nodoc\ iso _TestHandshakeConnectionMultiToken is UnitTest
       s.clone().iso_array()
     end
     let parser = _HandshakeParser
-    match parser(consume request, 8192)
+    match \exhaustive\ parser(consume request, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String]("/", result.request.uri)
     | _HandshakeNeedMore => h.fail("expected result")
@@ -368,7 +368,7 @@ class \nodoc\ iso _TestHandshakePropertyValidRequests is Property1[String]
     let test_uri: String val = "/" + uri_suffix
     let data = _TestHandshakeHelper.valid_request(where uri = test_uri)
     let parser = _HandshakeParser
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String](test_uri, result.request.uri)
     | _HandshakeNeedMore =>
@@ -391,7 +391,7 @@ class \nodoc\ iso _TestHandshakePropertyValidKeys is Property1[String]
     let key: String val = Base64.encode(raw_key)
     let data = _TestHandshakeHelper.valid_request(where key = key)
     let parser = _HandshakeParser
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | let result: _HandshakeResult => None // success expected
     | _HandshakeNeedMore =>
       h.fail("expected result for key: " + key)
@@ -416,7 +416,7 @@ class \nodoc\ iso _TestHandshakePropertyInvalidKeyLength is Property1[String]
     let key: String val = Base64.encode(raw_key)
     let data = _TestHandshakeHelper.valid_request(where key = key)
     let parser = _HandshakeParser
-    match parser(consume data, 8192)
+    match \exhaustive\ parser(consume data, 8192)
     | HandshakeInvalidKey => None // expected
     | _HandshakeNeedMore =>
       h.fail("expected HandshakeInvalidKey for key: " + key)

--- a/mare/web_socket_server.pony
+++ b/mare/web_socket_server.pony
@@ -138,15 +138,15 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
 
   fun ref _feed_handshake(data: Array[U8] iso) =>
     """Process incoming data during the handshake phase."""
-    let max_size = match _config
+    let max_size = match \exhaustive\ _config
       | let c: WebSocketConfig val => c.max_handshake_size
       | None => _Unreachable(); return
       end
 
-    match _handshake_parser(consume data, max_size)
+    match \exhaustive\ _handshake_parser(consume data, max_size)
     | _HandshakeNeedMore => None
     | let result: _HandshakeResult =>
-      match _lifecycle_event_receiver
+      match \exhaustive\ _lifecycle_event_receiver
       | let r: WebSocketLifecycleEventReceiver ref =>
         if r.on_upgrade_request(result.request) then
           // Accept: send 101 response
@@ -184,7 +184,7 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
 
   fun ref _feed_frames_from_val(data: Array[U8] val) =>
     """Process incoming frame data from a val array."""
-    match _frame_parser.parse(data)
+    match \exhaustive\ _frame_parser.parse(data)
     | let frames: Array[_ParsedFrame val] val =>
       for frame in frames.values() do
         _dispatch_frame(frame)
@@ -203,7 +203,7 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
   fun ref _feed_frames_closing(data: Array[U8] iso) =>
     """Process incoming frame data in the Closing state."""
     let data_val: Array[U8] val = consume data
-    match _frame_parser.parse(data_val)
+    match \exhaustive\ _frame_parser.parse(data_val)
     | let frames: Array[_ParsedFrame val] val =>
       for frame in frames.values() do
         match frame.opcode
@@ -252,12 +252,12 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
       _state = _Closed
     else
       // Data frame (text, binary, continuation) — reassemble
-      let max_size = match _config
+      let max_size = match \exhaustive\ _config
         | let c: WebSocketConfig val => c.max_message_size
         | None => _Unreachable(); return
         end
 
-      match _reassembler.frame(
+      match \exhaustive\ _reassembler.frame(
         frame.fin, frame.opcode, frame.payload, max_size)
       | let msg: _CompleteMessage =>
         if msg.is_text then
@@ -314,19 +314,19 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     _tcp_connection.send(response)
 
   fun ref _fire_on_open(request: UpgradeRequest val) =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: WebSocketLifecycleEventReceiver ref => r.on_open(request)
     | None => _Unreachable()
     end
 
   fun ref _fire_on_text(data: String val) =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: WebSocketLifecycleEventReceiver ref => r.on_text_message(data)
     | None => _Unreachable()
     end
 
   fun ref _fire_on_binary(data: Array[U8] val) =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: WebSocketLifecycleEventReceiver ref =>
       r.on_binary_message(data)
     | None => _Unreachable()
@@ -336,20 +336,20 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     close_status: CloseStatus,
     close_reason: String val)
   =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: WebSocketLifecycleEventReceiver ref =>
       r.on_closed(close_status, close_reason)
     | None => _Unreachable()
     end
 
   fun ref _fire_on_throttled() =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: WebSocketLifecycleEventReceiver ref => r.on_throttled()
     | None => _Unreachable()
     end
 
   fun ref _fire_on_unthrottled() =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: WebSocketLifecycleEventReceiver ref => r.on_unthrottled()
     | None => _Unreachable()
     end


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.