### PR TITLE
Update lori to 0.14.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ make examples ssl=3.0.x # Just examples
 
 ## Dependencies
 
-- **lori** (0.13.1) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
+- **lori** (0.14.1) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
 - **ssl** (2.0.1) — SHA-1 digest for computing the WebSocket handshake accept key (`ssl/crypto`). Also provides `ssl/net` for WSS (TLS) support.
 - **stdlib encode/base64** — Base64 encoding/decoding for the handshake accept key.
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.0"
+      "version": "0.14.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Bumps the lori dependency from 0.14.0 to 0.14.1.

0.14.1 adds `_on_idle_timer_failure` and `_on_timer_failure` lifecycle callbacks with no-op defaults. Mare doesn't expose `idle_timeout` or `set_timer` through its public API, so timer-subscription failures can't reach mare users today — we take lori's default no-ops. If mare ever exposes timer APIs (see #35 for the user-timer gap), we'll revisit.

No changelog or release notes since there's no user-visible change.