### PR TITLE
Require ponyc 0.64.0 or later

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.release-notes/require-ponyc-0.64.0.md
+++ b/.release-notes/require-ponyc-0.64.0.md
@@ -1,0 +1,5 @@
+## Require ponyc 0.64.0 or later
+
+mare now requires ponyc 0.64.0 or later. The previous minimum was 0.63.1.
+
+This is driven by an update to lori 0.15.0, which requires ponyc 0.64.0 for changes to FFI declaration syntax and the runtime socket API. Older ponyc versions will fail to compile mare.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ make examples ssl=3.0.x # Just examples
 
 ## Dependencies
 
-- **lori** (0.14.1) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
+- **lori** (0.15.0) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
 - **ssl** (2.0.1) — SHA-1 digest for computing the WebSocket handshake accept key (`ssl/crypto`). Also provides `ssl/net` for WSS (TLS) support.
 - **stdlib encode/base64** — Base64 encoding/decoding for the handshake accept key.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mare is beta quality software that will change frequently. Expect breaking chang
 
 ## Installation
 
-* Requires ponyc 0.63.1 or later
+* Requires ponyc 0.64.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/mare.git --version 0.3.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.1"
+      "version": "0.15.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates mare to use lori 0.15.0, which requires ponyc 0.64.0 or later. Switches CI workflows that pull `shared-docker-ci-standard-builder-with-libressl-4.2.1` and `library-documentation-action-v2` from the `:release` channel to `:nightly` so they can build against the soon-to-be-released ponyc 0.64.0.

Will need a follow-up to switch back to `:release` once ponyc 0.64.0 ships (tracked in ponylang/ponyc#5298).