### PR TITLE
Fix server no longer receiving messages after a large send

### DIFF
--- a/.release-notes/fix-silent-connection-after-large-send.md
+++ b/.release-notes/fix-silent-connection-after-large-send.md
@@ -1,0 +1,3 @@
+## Fix server no longer receiving messages after a large send
+
+After sending a large amount of data, a connection could stop delivering incoming messages — your message handler would never fire again. No error was raised and the connection was not closed; it simply went quiet, even though the client was still sending. This most often showed up on servers that keep sending while still receiving, such as echo, relay, or broadcast servers. Incoming messages are now delivered as expected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ make examples ssl=3.0.x # Just examples
 
 ## Dependencies
 
-- **lori** (0.15.0) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
+- **lori** (0.15.1) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
 - **ssl** (2.0.1) — SHA-1 digest for computing the WebSocket handshake accept key (`ssl/crypto`). Also provides `ssl/net` for WSS (TLS) support.
 - **stdlib encode/base64** — Base64 encoding/decoding for the handshake accept key.
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.0"
+      "version": "0.15.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.15.1, which fixes a server that could stop delivering incoming messages after a large send drained under backpressure.