### PR TITLE
Fix connections closed mid-transfer by the idle timeout

### DIFF
--- a/.release-notes/fix-idle-timeout-mid-transfer.md
+++ b/.release-notes/fix-idle-timeout-mid-transfer.md
@@ -1,0 +1,3 @@
+## Fix connections closed mid-transfer by the idle timeout
+
+A connection could be closed by its idle timeout while it was still actively transferring data to a slow peer. A large transfer draining slowly to a slow reader looked idle even though data was still moving, so it was closed mid-transfer. A connection is now closed by the idle timeout only when no data has moved in either direction for the timeout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ make examples ssl=3.0.x # Just examples
 
 ## Dependencies
 
-- **lori** (0.16.0) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
+- **lori** (0.16.1) — TCP networking. Provides `TCPListener`, `TCPConnection`, and the actor/lifecycle-receiver pattern.
 - **ssl** (2.0.1) — SHA-1 digest for computing the WebSocket handshake accept key (`ssl/crypto`). Also provides `ssl/net` for WSS (TLS) support.
 - **stdlib encode/base64** — Base64 encoding/decoding for the handshake accept key.
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.0"
+      "version": "0.16.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.16.1, which fixes the idle timer resetting on outgoing drains.

A connection could be closed by its idle timeout while still actively transferring data to a slow peer — the transfer looked idle even though bytes were still moving. A connection is now closed by the idle timeout only when no data has moved for the timeout.