### PR TITLE
Update lori to 0.17.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,75 @@
+## Fix dropped messages when a connection closes under backpressure
+
+When the socket cannot take more data, messages you send with `send_text()` and `send_binary()` are queued until it can, and `on_throttled()` fires. Anything still in that queue when the connection closed was discarded, so the client never received it. Queued data is now written out before the connection shuts down.
+
+This matters most for `close()`, which sends a WebSocket close frame and then shuts the connection down. A message sent shortly before `close()` now reaches the client instead of being discarded.
+
+## Fix a hang when closing a connection while handling a message
+
+Closing a connection while handling a message that had just arrived — a `close()` from `on_text_message()` or `on_binary_message()`, or the close handshake completing when the client's close frame comes in — could leave one more read outstanding on the socket that had just been closed. With many connections opening and closing, that read could block one of the runtime's scheduler threads and keep the program from exiting.
+
+## Fix a hang when sending under load
+
+Under write load, sending on a connection could hang the whole program. When the operating system's send buffer filled on a blocking file descriptor, the write stalled and never returned. Connections use non-blocking descriptors, so this was reachable only after the operating system had reused a closed connection's descriptor number for a blocking socket elsewhere in the process — rare, but possible.
+
+This is fixed on Linux, FreeBSD, OpenBSD, and DragonFly. macOS and Windows are unchanged.
+
+## Add HandshakeAcceptKeyFailed to HandshakeError
+
+Computing the `Sec-WebSocket-Accept` value takes a SHA-1, and that can now fail rather than crash or return a wrong hash. When it does, the handshake fails with a new `HandshakeError` member, `HandshakeAcceptKeyFailed`, and the server answers 500 Internal Server Error — the request was well formed, so 400 would be wrong.
+
+Nothing else reports this error, and only an environment that cannot give OpenSSL a digest context produces it.
+
+Code that matches `HandshakeError` exhaustively needs a new branch:
+
+```pony
+// Before
+match \exhaustive\ err
+| HandshakeRequestTooLarge => None
+| HandshakeInvalidHTTP => None
+| HandshakeMissingHost => None
+| HandshakeMissingUpgrade => None
+| HandshakeWrongVersion => None
+| HandshakeMissingKey => None
+| HandshakeInvalidKey => None
+end
+
+// After
+match \exhaustive\ err
+| HandshakeRequestTooLarge => None
+| HandshakeInvalidHTTP => None
+| HandshakeMissingHost => None
+| HandshakeMissingUpgrade => None
+| HandshakeWrongVersion => None
+| HandshakeMissingKey => None
+| HandshakeInvalidKey => None
+| HandshakeAcceptKeyFailed => None
+end
+```
+
+## Require ponyc 0.67.0 or later
+
+mare now requires ponyc 0.67.0 or later on every platform. The previous minimum was 0.64.0, and 0.66.0 on Windows; 0.64.0 through 0.66.x are no longer supported. The write hang under load is closed by a socket call that ponyc added in 0.67.0.
+
+## Move to ponylang/ssl 3.0.0
+
+mare now depends on ponylang/ssl 3.0.0, where it depended on 2.0.1. If your application does not declare ssl itself, it picks up 3.0.0 through mare, and your own `use "ssl/net"` and `use "ssl/crypto"` code is built against it. If your application does declare ssl, your declaration is the one that applies.
+
+Nothing in mare's own API changed: `WebSocketServer.ssl()` still takes an `SSLContext val`. The breaking changes are in your own ssl code. The one most likely to hit you is the renaming of the twelve protocol version primitives, which now spell their acronyms in full. These are the values you pass to `set_min_proto_version` and `set_max_proto_version` on the context you hand to mare:
+
+```pony
+// Before
+ctx.set_min_proto_version(Tls1u2Version())?
+
+// After
+ctx.set_min_proto_version(TLS1u2Version())?
+```
+
+The rest of ponylang/ssl's breaking changes:
+
+- `Digest` construction, `Digest.final`, and `HmacSha256` are now partial and need a `?`.
+- `SSLContext.alpn_set_resolver` takes an `ALPNProtocolResolver val`, where it took a `box`.
+- `SSLState` has a new member, `SSLDisposed`. An exhaustive match on `SSL.state()` does not compile until you handle it.
+- A reference typed `HashFn tag` no longer compiles. Type it `val` or `box`.
+
+See ponylang/ssl's 3.0.0 release notes for more on each of these.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ make test-one t=TestName ssl=3.0.x  # run a single test by name
 make examples ssl=3.0.x             # examples only
 ```
 
-`ssl=` is required because mare uses `ssl/crypto` for the SHA-1 that computes the WebSocket handshake accept key.
+`ssl=` is required because mare uses `ssl/crypto` for the SHA-1 that computes the WebSocket handshake accept key. Set it to your installed TLS library: `4.0.x`, `3.0.x`, `1.1.x`, or `libressl`.
 
 ## Connection states
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix dropped messages when a connection closes under backpressure ([PR #58](https://github.com/ponylang/mare/pull/58))
+- Fix a hang when closing a connection while handling a message ([PR #58](https://github.com/ponylang/mare/pull/58))
+- Fix a hang when sending under load ([PR #58](https://github.com/ponylang/mare/pull/58))
+
 
 ### Added
 
 
+
 ### Changed
+
+- Add HandshakeAcceptKeyFailed to HandshakeError ([PR #58](https://github.com/ponylang/mare/pull/58))
+- Require ponyc 0.67.0 or later ([PR #58](https://github.com/ponylang/mare/pull/58))
+- Move to ponylang/ssl 3.0.0 ([PR #58](https://github.com/ponylang/mare/pull/58))
 
 
 ## [0.5.1] - 2026-06-30

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs TAGS))
-  ifeq ($(ssl), 3.0.x)
+  ifeq ($(ssl), 4.0.x)
+          SSL = -Dopenssl_4.0.x
+  else ifeq ($(ssl), 3.0.x)
           SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
           SSL = -Dopenssl_1.1.x

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ mare is beta quality software that will change frequently. Expect breaking chang
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later.
+* Requires ponyc 0.67.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/mare.git --version 0.5.1`
 * `corral fetch` to fetch your dependencies
 * `use "mare"` to include this package
 * `corral run -- ponyc` to compile your application
 
-Mare has a transitive dependency on [ponylang/ssl](https://github.com/ponylang/ssl). It requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl?tab=readme-ov-file#installation) for more information.
+Mare depends on [ponylang/ssl](https://github.com/ponylang/ssl). It requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl?tab=readme-ov-file#installation) for more information.
 
 ## Usage
 

--- a/corral.json
+++ b/corral.json
@@ -13,11 +13,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.1"
+      "version": "0.17.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.1"
+      "version": "3.0.0"
     }
   ]
 }

--- a/mare/_handshake_parser.pony
+++ b/mare/_handshake_parser.pony
@@ -148,7 +148,12 @@ class _HandshakeParser
             return HandshakeInvalidKey
           end
         if decoded_size != 16 then return HandshakeInvalidKey end
-        let accept_key = _compute_accept_key(key)
+        let accept_key =
+          try
+            _compute_accept_key(key)?
+          else
+            return HandshakeAcceptKeyFailed
+          end
 
         // Extract remaining bytes after \r\n\r\n using String
         // intermediary: build ref String, clone to iso, iso_array to val
@@ -169,23 +174,17 @@ class _HandshakeParser
       HandshakeInvalidHTTP
     end
 
-  fun _compute_accept_key(key: String val): String val =>
+  fun _compute_accept_key(key: String val): String val ? =>
     """
     Compute the Sec-WebSocket-Accept value.
 
     Concatenates the client key with the WebSocket GUID, takes the SHA-1
-    hash, and Base64-encodes the result.
+    hash, and Base64-encodes the result. Raises when the hash cannot be
+    taken.
     """
     let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-    let sha = crypto.Digest.sha1()
-    try
-      sha.>append(key)?.append(magic)?
-    else
-      _Unreachable()
-    end
-    let hash = sha.final()
-    let encoded: String val = Base64.encode(hash)
-    encoded
+    Base64.encode(
+      crypto.Digest.sha1()?.>append(key)?.>append(magic)?.final()?)
 
 class val _HandshakeResult
   """A successfully parsed WebSocket upgrade request."""

--- a/mare/_test_handshake_parser.pony
+++ b/mare/_test_handshake_parser.pony
@@ -1,7 +1,6 @@
 use "pony_test"
 use "pony_check"
 use "encode/base64"
-use crypto = "ssl/crypto"
 
 primitive \nodoc\ _TestHandshakeHelper
   """Helpers for building HTTP upgrade requests."""
@@ -28,14 +27,6 @@ primitive \nodoc\ _TestHandshakeHelper
       .>append("\r\n")
     s.clone().iso_array()
 
-  fun compute_accept_key(key: String val): String val =>
-    """Compute expected Sec-WebSocket-Accept value."""
-    let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-    let sha = crypto.Digest.sha1()
-    try sha.>append(key)?.append(magic)? else _Unreachable() end
-    let hash = sha.final()
-    Base64.encode(hash)
-
 class \nodoc\ iso _TestHandshakeValid is UnitTest
   """Valid complete upgrade request produces correct result."""
   fun name(): String => "handshake/valid_complete"
@@ -46,10 +37,8 @@ class \nodoc\ iso _TestHandshakeValid is UnitTest
     match \exhaustive\ parser(consume data, 8192)
     | let result: _HandshakeResult =>
       h.assert_eq[String]("/", result.request.uri)
-      let expected_key =
-        _TestHandshakeHelper.compute_accept_key(
-          "dGhlIHNhbXBsZSBub25jZQ==")
-      h.assert_eq[String](expected_key, result.accept_key)
+      h.assert_eq[String](
+        "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", result.accept_key)
       h.assert_eq[USize](0, result.remaining.size())
     | _HandshakeNeedMore =>
       h.fail("expected result, got need more")

--- a/mare/handshake_error.pony
+++ b/mare/handshake_error.pony
@@ -6,7 +6,8 @@ type HandshakeError is
   | HandshakeMissingUpgrade
   | HandshakeWrongVersion
   | HandshakeMissingKey
-  | HandshakeInvalidKey )
+  | HandshakeInvalidKey
+  | HandshakeAcceptKeyFailed )
 
 primitive HandshakeRequestTooLarge is Stringable
   """The HTTP upgrade request exceeded the maximum allowed size."""
@@ -55,3 +56,15 @@ primitive HandshakeInvalidKey is Stringable
   fun string(): String iso^ =>
     """Returns a human-readable description of this error."""
     "Invalid Sec-WebSocket-Key (must be base64-encoded 16 bytes)".clone()
+
+primitive HandshakeAcceptKeyFailed is Stringable
+  """
+  The Sec-WebSocket-Accept value could not be computed.
+
+  The request was well formed; the SHA-1 the accept value is built from
+  could not be taken. A server that reports this answers 500 rather than
+  400, because nothing about the client's request was wrong.
+  """
+  fun string(): String iso^ =>
+    """Returns a human-readable description of this error."""
+    "Could not compute Sec-WebSocket-Accept".clone()

--- a/mare/web_socket_server.pony
+++ b/mare/web_socket_server.pony
@@ -103,8 +103,9 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
 
   fun ref _on_started() => None
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _state.on_received(this, consume data)
+    lori.KeepReading
 
   fun ref _on_closed() =>
     _state.on_closed(this)
@@ -172,6 +173,8 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
       | HandshakeWrongVersion =>
         _send_http_error("426 Upgrade Required",
           "Sec-WebSocket-Version: 13\r\n")
+      | HandshakeAcceptKeyFailed =>
+        _send_http_error("500 Internal Server Error")
       else
         _send_http_error("400 Bad Request")
       end


### PR DESCRIPTION
lori 0.17.0 has `_on_received` return a `ReadAction` saying whether the read loop should keep reading, and requires ponylang/ssl 3.0.0 and ponyc 0.67.0.

ponylang/ssl 3.0.0 makes `Digest` construction and `Digest.final` partial, so computing the Sec-WebSocket-Accept value has error paths it did not have before. They are reachable — an environment that cannot give OpenSSL a digest context reaches them — so they are not `_Unreachable()`. The handshake fails with a new `HandshakeError` member, `HandshakeAcceptKeyFailed`, and the server answers 500 Internal Server Error rather than 400, because the request was well formed and the failure is ours.

That adds a member to a public union, so code matching `HandshakeError` exhaustively needs a new branch. The release note carries the before/after.

Also drops the test twin of `_compute_accept_key`. Its one caller compared the parser's output against a second copy of the same algorithm, so it could not fail when the algorithm was wrong. `_TestHandshakeRfc6455AcceptKey` already pins the same key against the literal RFC 6455 value.

No test covers the new error path. It fires only when OpenSSL cannot allocate a digest context, and I could not find a way to force that from a test.
