### PR TITLE
Run the breakage test against ponyc main

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
The workflow is there so we find out about a ponyc change that breaks us before it lands in a release. The `release` image tag is the most recent ponyc release, so the job ran the same test against the same ponyc as `pr.yml`'s `vs-ponyc-release` job. The `nightly` tag on the same image is built from ponyc main.

Closes #59
