### PR TITLE
Fix additional SSL bugs and a macOS connection bug

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -2,3 +2,11 @@
 
 Fixed multiple bugs affecting SSL support, including handshake failures being reported as authentication failures, data being silently dropped on large writes and when encryption fails, and connections being closed by unrelated SSL failures elsewhere.
 
+## Fix additional SSL connection bugs
+
+Fixed additional bugs in SSL connection handling that could cause handshake failures to be misreported, data to be silently dropped during encrypted writes, and one connection's SSL failure to close a different connection.
+
+## Fix a macOS bug where setting up a connection could close an unrelated file descriptor
+
+On macOS, setting up a connection could close one of its own file descriptors twice. The operating system can hand that descriptor number to something else in between, so the second close lands on whatever got it — an unrelated connection or file closes silently. Connecting to a host that resolves to more than one address (including `localhost`) is the likeliest way to hit it. The same cleanup also miscounted outstanding connection attempts, which could abandon a working attempt and report the connection as failed, or leave a connection that was asked to close gracefully never finishing. Linux and Windows were not affected.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. This projec
 ### Fixed
 
 - Fix a number of SSL bugs ([PR #61](https://github.com/ponylang/mare/pull/61))
+- Fix additional SSL connection bugs ([PR #63](https://github.com/ponylang/mare/pull/63))
+- Fix a macOS bug where setting up a connection could close an unrelated file descriptor ([PR #63](https://github.com/ponylang/mare/pull/63))
 
 ### Added
 

--- a/corral.json
+++ b/corral.json
@@ -13,11 +13,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.17.0"
+      "version": "0.18.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "3.0.1"
+      "version": "4.0.0"
     }
   ]
 }


### PR DESCRIPTION
Updates lori to 0.18.0 and ssl to 4.0.0. Fixes additional SSL connection bugs beyond what ssl 3.0.1 addressed, and a macOS bug where setting up a connection could close an unrelated file descriptor.
