### PR TITLE
Add pony-lint and fix all style errors

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,10 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all examples clean TAGS test test-one
+LINT_WITH := corral run -- pony-lint
+
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
+
+.PHONY: all examples clean TAGS test test-one lint

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 	PONYC = $(COMPILE_WITH) --debug
 endif
 
-ifeq (,$(filter $(MAKECMDGOALS),clean docs TAGS))
+ifeq (,$(filter $(MAKECMDGOALS),clean docs lint TAGS))
   ifeq ($(ssl), 4.0.x)
           SSL = -Dopenssl_4.0.x
   else ifeq ($(ssl), 3.0.x)

--- a/examples/chat/chat.pony
+++ b/examples/chat/chat.pony
@@ -1,0 +1,4 @@
+"""
+A multi-client chat server that broadcasts messages to all connected
+clients.
+"""

--- a/examples/chat/main.pony
+++ b/examples/chat/main.pony
@@ -1,13 +1,3 @@
-"""
-A multi-client chat server that broadcasts messages to all connected clients.
-
-Demonstrates inter-actor communication: `ChatHandler` actors register with
-`ChatListener`, which maintains a set of connected handlers. When a client
-sends a message, its handler asks the listener to broadcast to all other
-handlers.
-
-Connect multiple clients with: `websocat ws://localhost:8083`
-"""
 use collections = "collections"
 use lori = "lori"
 use ws = "../../mare"
@@ -15,17 +5,22 @@ use ws = "../../mare"
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    let config = ws.WebSocketConfig(where
-      host' = "localhost",
-      port' = "8083")
+    let config =
+      ws.WebSocketConfig(where
+        host' = "localhost",
+        port' = "8083")
     ChatListener(auth, config, env.out)
 
 actor ChatListener is lori.TCPListenerActor
+  """
+  Listens for TCP connections and spawns a ChatHandler for each one.
+  """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: ws.WebSocketConfig val
   let _out: OutStream
-  let _handlers: collections.SetIs[ChatHandler tag] = collections.SetIs[ChatHandler tag]
+  let _handlers: collections.SetIs[ChatHandler tag] =
+    collections.SetIs[ChatHandler tag]
 
   new create(
     auth: lori.TCPListenAuth,
@@ -64,6 +59,9 @@ actor ChatListener is lori.TCPListenerActor
     end
 
 actor ChatHandler is ws.WebSocketServerActor
+  """
+  Handles a single chat client's WebSocket connection.
+  """
   var _ws: ws.WebSocketServer = ws.WebSocketServer.none()
   let _out: OutStream
   let _listener_tag: ChatListener tag

--- a/examples/close-codes/close_codes.pony
+++ b/examples/close-codes/close_codes.pony
@@ -1,0 +1,4 @@
+"""
+A WebSocket server that demonstrates server-initiated close and close
+status handling.
+"""

--- a/examples/close-codes/main.pony
+++ b/examples/close-codes/main.pony
@@ -1,26 +1,19 @@
-"""
-A WebSocket server that demonstrates server-initiated close and close
-status handling.
-
-Send "goodbye" to trigger a normal close (1000), "kick" to trigger a
-policy violation close (1008), or any other message to echo it back.
-The `on_closed` callback matches on `CloseStatus` variants to log how
-the connection closed.
-
-Connect with: `websocat ws://localhost:8082`
-"""
 use lori = "lori"
 use ws = "../../mare"
 
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    let config = ws.WebSocketConfig(where
-      host' = "localhost",
-      port' = "8082")
+    let config =
+      ws.WebSocketConfig(where
+        host' = "localhost",
+        port' = "8082")
     CloseListener(auth, config, env.out)
 
 actor CloseListener is lori.TCPListenerActor
+  """
+  Listens for TCP connections and spawns a CloseHandler for each one.
+  """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: ws.WebSocketConfig val
@@ -48,6 +41,9 @@ actor CloseListener is lori.TCPListenerActor
     _out.print("Failed to listen on " + _config.host + ":" + _config.port)
 
 actor CloseHandler is ws.WebSocketServerActor
+  """
+  Handles a single client connection, demonstrating close status codes.
+  """
   var _ws: ws.WebSocketServer = ws.WebSocketServer.none()
   let _out: OutStream
 

--- a/examples/echo/echo.pony
+++ b/examples/echo/echo.pony
@@ -1,0 +1,3 @@
+"""
+A WebSocket echo server that echoes back text and binary messages.
+"""

--- a/examples/echo/main.pony
+++ b/examples/echo/main.pony
@@ -1,21 +1,19 @@
-"""
-A WebSocket echo server that echoes back text and binary messages.
-
-Connect with any WebSocket client (e.g., websocat, browser JS) to
-ws://localhost:8080 and messages will be echoed back.
-"""
 use lori = "lori"
 use ws = "../../mare"
 
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    let config = ws.WebSocketConfig(where
-      host' = "localhost",
-      port' = "8080")
+    let config =
+      ws.WebSocketConfig(where
+        host' = "localhost",
+        port' = "8080")
     EchoListener(auth, config, env.out)
 
 actor EchoListener is lori.TCPListenerActor
+  """
+  Listens for TCP connections and spawns an EchoHandler for each one.
+  """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: ws.WebSocketConfig val
@@ -43,6 +41,9 @@ actor EchoListener is lori.TCPListenerActor
     _out.print("Failed to listen on " + _config.host + ":" + _config.port)
 
 actor EchoHandler is ws.WebSocketServerActor
+  """
+  Handles a single client connection, echoing messages back.
+  """
   var _ws: ws.WebSocketServer = ws.WebSocketServer.none()
   let _out: OutStream
 

--- a/examples/request-filter/main.pony
+++ b/examples/request-filter/main.pony
@@ -1,25 +1,19 @@
-"""
-A WebSocket server that filters connections by URI path and Origin header.
-
-Demonstrates `on_upgrade_request()` to accept or reject connections before
-the handshake completes. Only connections to `/ws` from origin
-`http://localhost` are accepted; all others receive 403 Forbidden.
-
-Connect with: `websocat -H "Origin: http://localhost" ws://localhost:8081/ws`
-Rejected:     `websocat ws://localhost:8081/nope`
-"""
 use lori = "lori"
 use ws = "../../mare"
 
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    let config = ws.WebSocketConfig(where
-      host' = "localhost",
-      port' = "8081")
+    let config =
+      ws.WebSocketConfig(where
+        host' = "localhost",
+        port' = "8081")
     FilterListener(auth, config, env.out)
 
 actor FilterListener is lori.TCPListenerActor
+  """
+  Listens for TCP connections and spawns a FilterHandler for each one.
+  """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: ws.WebSocketConfig val
@@ -47,6 +41,9 @@ actor FilterListener is lori.TCPListenerActor
     _out.print("Failed to listen on " + _config.host + ":" + _config.port)
 
 actor FilterHandler is ws.WebSocketServerActor
+  """
+  Handles a single client connection, filtering by URI and Origin.
+  """
   var _ws: ws.WebSocketServer = ws.WebSocketServer.none()
   let _out: OutStream
 
@@ -62,10 +59,11 @@ actor FilterHandler is ws.WebSocketServerActor
   fun ref _websocket(): ws.WebSocketServer => _ws
 
   fun ref on_upgrade_request(request: ws.UpgradeRequest val): Bool =>
-    let origin = match \exhaustive\ request.header("Origin")
-    | let o: String val => o
-    | None => ""
-    end
+    let origin =
+      match \exhaustive\ request.header("Origin")
+      | let o: String val => o
+      | None => ""
+      end
 
     if (request.uri == "/ws") and (origin == "http://localhost") then
       _out.print("Accepted: uri=" + request.uri

--- a/examples/request-filter/request_filter.pony
+++ b/examples/request-filter/request_filter.pony
@@ -1,0 +1,4 @@
+"""
+A WebSocket server that filters connections by URI path and Origin
+header.
+"""

--- a/examples/wss/main.pony
+++ b/examples/wss/main.pony
@@ -1,13 +1,3 @@
-"""
-A secure WebSocket (WSS) echo server using TLS with self-signed certificates.
-
-Demonstrates TLS support: creating an `SSLContext`, loading certificate and
-key files, and using `WebSocketServer.ssl` instead of `WebSocketServer` to
-create a secure connection.
-
-Must be run from the project root so the relative certificate paths resolve
-correctly. Test with: `websocat -k wss://localhost:8443`
-"""
 use "files"
 use ssl_net = "ssl/net"
 use lori = "lori"
@@ -34,12 +24,16 @@ actor Main
       end
 
     let auth = lori.TCPListenAuth(env.root)
-    let config = ws.WebSocketConfig(where
-      host' = "localhost",
-      port' = "8443")
+    let config =
+      ws.WebSocketConfig(where
+        host' = "localhost",
+        port' = "8443")
     WssListener(auth, config, env.out, sslctx)
 
 actor WssListener is lori.TCPListenerActor
+  """
+  Listens for TLS connections and spawns a WssHandler for each one.
+  """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: ws.WebSocketConfig val
@@ -70,6 +64,9 @@ actor WssListener is lori.TCPListenerActor
     _out.print("Failed to listen on " + _config.host + ":" + _config.port)
 
 actor WssHandler is ws.WebSocketServerActor
+  """
+  Handles a single TLS client connection, echoing messages back.
+  """
   var _ws: ws.WebSocketServer = ws.WebSocketServer.none()
   let _out: OutStream
 

--- a/examples/wss/wss.pony
+++ b/examples/wss/wss.pony
@@ -1,0 +1,4 @@
+"""
+A secure WebSocket (WSS) echo server using TLS with self-signed
+certificates.
+"""

--- a/mare/_close_status_extractor.pony
+++ b/mare/_close_status_extractor.pony
@@ -26,17 +26,18 @@ primitive _CloseStatusExtractor
       let code = (payload(0)?.u16() << 8) or payload(1)?.u16()
       let status = _code_to_status(code)
 
-      let reason = if payload.size() > 2 then
-        let s = String(payload.size() - 2)
-        var i: USize = 2
-        while i < payload.size() do
-          s.push(payload(i)?)
-          i = i + 1
+      let reason =
+        if payload.size() > 2 then
+          let s = String(payload.size() - 2)
+          var i: USize = 2
+          while i < payload.size() do
+            s.push(payload(i)?)
+            i = i + 1
+          end
+          s.clone()
+        else
+          ""
         end
-        s.clone()
-      else
-        ""
-      end
 
       (status, consume reason)
     else

--- a/mare/_connection_state.pony
+++ b/mare/_connection_state.pony
@@ -12,37 +12,57 @@ trait val _ConnectionState
   """
 
   fun on_received(server: WebSocketServer ref, data: Array[U8] iso)
-    """Handle incoming data from the TCP connection."""
+    """
+    Handle incoming data from the TCP connection.
+    """
 
   fun on_closed(server: WebSocketServer ref)
-    """Handle connection close notification."""
+    """
+    Handle connection close notification.
+    """
 
   fun on_throttled(server: WebSocketServer ref)
-    """Handle backpressure applied notification."""
+    """
+    Handle backpressure applied notification.
+    """
 
   fun on_unthrottled(server: WebSocketServer ref)
-    """Handle backpressure released notification."""
+    """
+    Handle backpressure released notification.
+    """
 
   fun on_sent(server: WebSocketServer ref, token: lori.SendToken)
-    """Handle send completion notification from lori."""
+    """
+    Handle send completion notification from lori.
+    """
 
   fun on_idle_timeout(server: WebSocketServer ref)
-    """Handle connection going idle."""
+    """
+    Handle connection going idle.
+    """
 
   fun send_text(server: WebSocketServer ref, data: String val)
-    """Send a text message."""
+    """
+    Send a text message.
+    """
 
   fun send_binary(server: WebSocketServer ref, data: Array[U8] val)
-    """Send a binary message."""
+    """
+    Send a binary message.
+    """
 
   fun close(
     server: WebSocketServer ref,
     code: CloseCode,
     reason: String val)
-    """Initiate a close handshake."""
+    """
+    Initiate a close handshake.
+    """
 
 primitive _Handshaking is _ConnectionState
-  """Parsing the HTTP upgrade request. No WebSocket messages yet."""
+  """
+  Parsing the HTTP upgrade request. No WebSocket messages yet.
+  """
 
   fun on_received(server: WebSocketServer ref, data: Array[U8] iso) =>
     server._feed_handshake(consume data)
@@ -56,7 +76,12 @@ primitive _Handshaking is _ConnectionState
   fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
   fun on_idle_timeout(server: WebSocketServer ref) => None
   fun send_text(server: WebSocketServer ref, data: String val) => None
-  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) => None
+
+  fun send_binary(
+    server: WebSocketServer ref,
+    data: Array[U8] val)
+  =>
+    None
 
   fun close(
     server: WebSocketServer ref,
@@ -66,7 +91,9 @@ primitive _Handshaking is _ConnectionState
     None
 
 primitive _Open is _ConnectionState
-  """WebSocket connection is open — exchanging messages."""
+  """
+  WebSocket connection is open — exchanging messages.
+  """
 
   fun on_received(server: WebSocketServer ref, data: Array[U8] iso) =>
     server._feed_frames(consume data)
@@ -122,7 +149,12 @@ primitive _Closing is _ConnectionState
   fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
   fun on_idle_timeout(server: WebSocketServer ref) => None
   fun send_text(server: WebSocketServer ref, data: String val) => None
-  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) => None
+
+  fun send_binary(
+    server: WebSocketServer ref,
+    data: Array[U8] val)
+  =>
+    None
 
   fun close(
     server: WebSocketServer ref,
@@ -132,7 +164,9 @@ primitive _Closing is _ConnectionState
     None
 
 primitive _Closed is _ConnectionState
-  """Connection is closed — all operations are no-ops."""
+  """
+  Connection is closed — all operations are no-ops.
+  """
 
   fun on_received(server: WebSocketServer ref, data: Array[U8] iso) => None
   fun on_closed(server: WebSocketServer ref) => None
@@ -141,7 +175,12 @@ primitive _Closed is _ConnectionState
   fun on_sent(server: WebSocketServer ref, token: lori.SendToken) => None
   fun on_idle_timeout(server: WebSocketServer ref) => None
   fun send_text(server: WebSocketServer ref, data: String val) => None
-  fun send_binary(server: WebSocketServer ref, data: Array[U8] val) => None
+
+  fun send_binary(
+    server: WebSocketServer ref,
+    data: Array[U8] val)
+  =>
+    None
 
   fun close(
     server: WebSocketServer ref,

--- a/mare/_fragment_reassembler.pony
+++ b/mare/_fragment_reassembler.pony
@@ -73,14 +73,18 @@ class _FragmentReassembler
     end
 
   fun ref _reset() =>
-    """Reset reassembly state for the next message."""
+    """
+    Reset reassembly state for the next message.
+    """
     _in_progress = false
     _is_text = false
     _buf = Array[U8]
     _total_size = 0
 
 class val _CompleteMessage
-  """A fully reassembled WebSocket message."""
+  """
+  A fully reassembled WebSocket message.
+  """
   let is_text: Bool
   let data: Array[U8] val
 
@@ -89,10 +93,14 @@ class val _CompleteMessage
     data = data'
 
 primitive _FragmentContinue
-  """More fragments are expected to complete the message."""
+  """
+  More fragments are expected to complete the message.
+  """
 
 class val _ReassemblyError
-  """A reassembly error with the close code to send."""
+  """
+  A reassembly error with the close code to send.
+  """
   let code: CloseCode
 
   new val create(code': CloseCode) =>

--- a/mare/_frame_encoder.pony
+++ b/mare/_frame_encoder.pony
@@ -7,35 +7,48 @@ primitive _FrameEncoder
   """
 
   fun text(data: String val): Array[U8] val =>
-    """Encode a text message frame (FIN=1, opcode=0x1)."""
+    """
+    Encode a text message frame (FIN=1, opcode=0x1).
+    """
     _encode(true, 0x01, data)
 
   fun binary(data: Array[U8] val): Array[U8] val =>
-    """Encode a binary message frame (FIN=1, opcode=0x2)."""
+    """
+    Encode a binary message frame (FIN=1, opcode=0x2).
+    """
     _encode(true, 0x02, data)
 
   fun close(code: CloseCode, reason: String val = ""): Array[U8] val =>
-    """Encode a close frame with a status code and optional reason."""
+    """
+    Encode a close frame with a status code and optional reason.
+    """
     let code_val = code.code()
-    let payload = recover iso
-      let p = Array[U8](2 + reason.size())
-      p.>push((code_val >> 8).u8())
-        .>push((code_val and 0xFF).u8())
-      p.append(reason)
-      p
-    end
+    let payload =
+      recover iso
+        let p = Array[U8](2 + reason.size())
+        p .> push((code_val >> 8).u8())
+          .> push((code_val and 0xFF).u8())
+        p.append(reason)
+        p
+      end
     _encode(true, 0x08, consume payload)
 
   fun close_payload(payload: Array[U8] val): Array[U8] val =>
-    """Encode a close frame echoing back the client's raw close payload."""
+    """
+    Encode a close frame echoing back the client's raw close payload.
+    """
     _encode(true, 0x08, payload)
 
   fun close_empty(): Array[U8] val =>
-    """Encode a close frame with no payload."""
+    """
+    Encode a close frame with no payload.
+    """
     _encode(true, 0x08, recover val Array[U8] end)
 
   fun pong(data: Array[U8] val): Array[U8] val =>
-    """Encode a pong frame echoing the ping payload."""
+    """
+    Encode a pong frame echoing the ping payload.
+    """
     _encode(true, 0x0A, data)
 
   fun _encode(fin: Bool, opcode: U8, payload: ByteSeq): Array[U8] val =>
@@ -65,17 +78,17 @@ primitive _FrameEncoder
         frame.push(payload_size.u8())
       elseif payload_size <= 65535 then
         frame.push(126)
-        frame.>push((payload_size >> 8).u8())
+        frame .> push((payload_size >> 8).u8())
           .push((payload_size and 0xFF).u8())
       else
         frame.push(127)
-        frame.>push((payload_size >> 56).u8())
-          .>push(((payload_size >> 48) and 0xFF).u8())
-          .>push(((payload_size >> 40) and 0xFF).u8())
-          .>push(((payload_size >> 32) and 0xFF).u8())
-          .>push(((payload_size >> 24) and 0xFF).u8())
-          .>push(((payload_size >> 16) and 0xFF).u8())
-          .>push(((payload_size >> 8) and 0xFF).u8())
+        frame .> push((payload_size >> 56).u8())
+          .> push(((payload_size >> 48) and 0xFF).u8())
+          .> push(((payload_size >> 40) and 0xFF).u8())
+          .> push(((payload_size >> 32) and 0xFF).u8())
+          .> push(((payload_size >> 24) and 0xFF).u8())
+          .> push(((payload_size >> 16) and 0xFF).u8())
+          .> push(((payload_size >> 8) and 0xFF).u8())
           .push((payload_size and 0xFF).u8())
       end
 

--- a/mare/_frame_parser.pony
+++ b/mare/_frame_parser.pony
@@ -34,7 +34,9 @@ class _FrameParser
     consume frames
 
   fun ref _try_parse_frame(): (_ParsedFrame val | _FrameError | None) =>
-    """Attempt to parse a single frame from the buffer."""
+    """
+    Attempt to parse a single frame from the buffer.
+    """
     if _buf.size() < 2 then return None end
 
     try
@@ -151,7 +153,8 @@ class _FrameParser
             reason_s.push(payload(ri)?)
             ri = ri + 1
           end
-          let reason_bytes: Array[U8] val = reason_s.clone().iso_array()
+          let reason_bytes: Array[U8] val =
+            reason_s.clone().iso_array()
           if not _Utf8Validator.is_valid(reason_bytes) then
             return _FrameError(CloseProtocolError)
           end
@@ -174,7 +177,9 @@ class _FrameParser
     end
 
   fun _valid_opcode(opcode: U8): Bool =>
-    """Check if the opcode is a known WebSocket opcode."""
+    """
+    Check if the opcode is a known WebSocket opcode.
+    """
     match opcode
     | 0x00 => true // Continuation
     | 0x01 => true // Text
@@ -186,7 +191,9 @@ class _FrameParser
     end
 
   fun _valid_close_code(code: U16): Bool =>
-    """Check if a close status code is valid to receive per RFC 6455."""
+    """
+    Check if a close status code is valid to receive per RFC 6455.
+    """
     // Coupling: _CloseStatusExtractor._code_to_status must stay in sync with
     // these valid code ranges. Adding new ranges here means adding
     // corresponding match arms in the extractor.
@@ -197,7 +204,9 @@ class _FrameParser
     end
 
 class val _ParsedFrame
-  """A parsed and unmasked WebSocket frame."""
+  """
+  A parsed and unmasked WebSocket frame.
+  """
   let fin: Bool
   let opcode: U8
   let payload: Array[U8] val
@@ -208,7 +217,9 @@ class val _ParsedFrame
     payload = payload'
 
 class val _FrameError
-  """A protocol violation detected during frame parsing."""
+  """
+  A protocol violation detected during frame parsing.
+  """
   let code: CloseCode
 
   new val create(code': CloseCode) =>

--- a/mare/_handshake_parser.pony
+++ b/mare/_handshake_parser.pony
@@ -35,7 +35,9 @@ class _HandshakeParser
     end
 
   fun _find_header_end(): (USize | None) =>
-    """Find the position of \\r\\n\\r\\n in the buffer."""
+    """
+    Find the position of \\r\\n\\r\\n in the buffer.
+    """
     if _buf.size() < 4 then return None end
     var i: USize = 0
     let limit = _buf.size() - 3
@@ -56,7 +58,9 @@ class _HandshakeParser
   fun _parse_request(header_end: USize)
     : (_HandshakeResult | HandshakeError)
   =>
-    """Parse the buffered HTTP request up to header_end."""
+    """
+    Parse the buffered HTTP request up to header_end.
+    """
     // Build request string from buffer bytes. String.clone() gives iso^
     // which auto-converts to val.
     let request_ref = String(header_end)
@@ -82,20 +86,23 @@ class _HandshakeParser
       if version != "HTTP/1.1" then return HandshakeInvalidHTTP end
 
       // Parse headers
-      let headers = recover val
-        let h = Array[(String val, String val)]
-        var j: USize = 1
-        while j < lines.size() do
-          let line = lines(j)?
-          let colon = try line.find(":")? else j = j + 1; continue end
-          // UpgradeRequest.header() depends on names being pre-lowered here.
-          let name: String val = line.substring(0, colon).lower()
-          let value: String val = line.substring(colon + 1).>strip()
-          h.push((name, value))
-          j = j + 1
+      let headers =
+        recover val
+          let h = Array[(String val, String val)]
+          var j: USize = 1
+          while j < lines.size() do
+            let line = lines(j)?
+            let colon =
+              try line.find(":")? else j = j + 1; continue end
+            // UpgradeRequest.header() depends on names being pre-lowered here.
+            let name: String val = line.substring(0, colon).lower()
+            let value: String val =
+              line.substring(colon + 1) .> strip()
+            h.push((name, value))
+            j = j + 1
+          end
+          h
         end
-        h
-      end
 
       // Validate required WebSocket headers
       var has_host = false
@@ -116,7 +123,8 @@ class _HandshakeParser
           // Connection header may contain multiple comma-separated tokens
           let tokens: Array[String val] val = value.split(",")
           for token in tokens.values() do
-            let trimmed: String val = token.clone().>strip()
+            let trimmed: String val =
+              token.clone() .> strip()
             let trimmed_lower: String val = trimmed.lower()
             if trimmed_lower == "upgrade" then
               has_connection_upgrade = true
@@ -131,7 +139,9 @@ class _HandshakeParser
 
       if not has_host then return HandshakeMissingHost end
       if not has_upgrade then return HandshakeMissingUpgrade end
-      if not has_connection_upgrade then return HandshakeMissingUpgrade end
+      if not has_connection_upgrade then
+        return HandshakeMissingUpgrade
+      end
 
       match \exhaustive\ websocket_version
       | let v: String val =>
@@ -161,10 +171,13 @@ class _HandshakeParser
         let remaining_s = String(_buf.size() - remaining_start)
         var k: USize = remaining_start
         while k < _buf.size() do
-          try remaining_s.push(_buf(k)?) else _Unreachable() end
+          try remaining_s.push(_buf(k)?)
+          else _Unreachable()
+          end
           k = k + 1
         end
-        let remaining: Array[U8] val = remaining_s.clone().iso_array()
+        let remaining: Array[U8] val =
+          remaining_s.clone().iso_array()
 
         let request = UpgradeRequest(uri, headers)
         _HandshakeResult(request, accept_key, remaining)
@@ -184,10 +197,15 @@ class _HandshakeParser
     """
     let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
     Base64.encode(
-      crypto.Digest.sha1()?.>append(key)?.>append(magic)?.final()?)
+      crypto.Digest.sha1()?
+        .> append(key)?
+        .> append(magic)?
+        .final()?)
 
 class val _HandshakeResult
-  """A successfully parsed WebSocket upgrade request."""
+  """
+  A successfully parsed WebSocket upgrade request.
+  """
   let request: UpgradeRequest val
   let accept_key: String val
   let remaining: Array[U8] val
@@ -202,4 +220,6 @@ class val _HandshakeResult
     remaining = remaining'
 
 primitive _HandshakeNeedMore
-  """More data is needed to complete the HTTP upgrade request."""
+  """
+  More data is needed to complete the HTTP upgrade request.
+  """

--- a/mare/_test_close_status.pony
+++ b/mare/_test_close_status.pony
@@ -61,20 +61,21 @@ class \nodoc\ _TestExtractorAllNamedCodes is UnitTest
     _check(h, 1011, CloseInternalError)
 
   fun _check(h: TestHelper, code: U16, expected: CloseStatus) =>
-    let payload: Array[U8] val = recover val
-      [as U8: (code >> 8).u8(); code.u8()]
-    end
+    let payload: Array[U8] val =
+      recover val
+        [as U8: (code >> 8).u8(); code.u8()]
+      end
     (let status, _) = _CloseStatusExtractor.from_payload(payload)
     h.assert_is[CloseStatus](expected, status)
 
 // -- Example-based tests for new types --
-
 class \nodoc\ _TestCloseNoStatusReceivedType is UnitTest
   fun name(): String => "CloseNoStatusReceived/code and string"
 
   fun apply(h: TestHelper) =>
     h.assert_eq[U16](1005, CloseNoStatusReceived.code())
-    h.assert_eq[String val]("1005 No Status Received",
+    h.assert_eq[String val](
+      "1005 No Status Received",
       CloseNoStatusReceived.string())
 
 class \nodoc\ _TestCloseAbnormalClosureType is UnitTest
@@ -82,7 +83,8 @@ class \nodoc\ _TestCloseAbnormalClosureType is UnitTest
 
   fun apply(h: TestHelper) =>
     h.assert_eq[U16](1006, CloseAbnormalClosure.code())
-    h.assert_eq[String val]("1006 Abnormal Closure",
+    h.assert_eq[String val](
+      "1006 Abnormal Closure",
       CloseAbnormalClosure.string())
 
 class \nodoc\ _TestOtherCloseCodeType is UnitTest
@@ -94,20 +96,22 @@ class \nodoc\ _TestOtherCloseCodeType is UnitTest
     h.assert_eq[String val]("3500 Other", c.string())
 
 // -- Property-based tests --
-
 class \nodoc\ _TestExtractorPropertyNamedCodes is Property1[U16]
   """All named code values produce their respective primitive."""
 
   fun name(): String => "CloseStatusExtractor/property: named codes"
 
   fun gen(): Generator[U16] =>
-    Generators.one_of[U16]([as U16: 1000; 1001; 1002; 1003
-      1007; 1008; 1009; 1011])
+    Generators.one_of[U16](
+      [ as U16: 1000; 1001; 1002; 1003
+        1007; 1008; 1009; 1011
+      ])
 
   fun property(sample: U16, h: PropertyHelper) =>
-    let payload: Array[U8] val = recover val
-      [as U8: (sample >> 8).u8(); sample.u8()]
-    end
+    let payload: Array[U8] val =
+      recover val
+        [as U8: (sample >> 8).u8(); sample.u8()]
+      end
     (let status, _) = _CloseStatusExtractor.from_payload(payload)
     match status
     | let _: OtherCloseCode =>
@@ -133,15 +137,17 @@ class \nodoc\ _TestExtractorPropertyOtherCodes is Property1[U16]
   fun gen(): Generator[U16] =>
     // Valid codes that don't have named primitives:
     // 1010, 1012-1014, 3000-4999
-    Generators.frequency[U16]([as (USize, Generator[U16]):
-      (1, Generators.one_of[U16]([as U16: 1010; 1012; 1013; 1014]))
-      (4, Generators.u16(3000, 4999))
-    ])
+    Generators.frequency[U16](
+      [ as (USize, Generator[U16]):
+        (1, Generators.one_of[U16]([as U16: 1010; 1012; 1013; 1014]))
+        (4, Generators.u16(3000, 4999))
+      ])
 
   fun property(sample: U16, h: PropertyHelper) =>
-    let payload: Array[U8] val = recover val
-      [as U8: (sample >> 8).u8(); sample.u8()]
-    end
+    let payload: Array[U8] val =
+      recover val
+        [as U8: (sample >> 8).u8(); sample.u8()]
+      end
     (let status, _) = _CloseStatusExtractor.from_payload(payload)
     match status
     | let o: OtherCloseCode =>
@@ -158,19 +164,22 @@ class \nodoc\ _TestExtractorPropertyRoundtrip is Property1[U16]
 
   fun gen(): Generator[U16] =>
     // All valid receivable codes: 1000-1003, 1007-1014, 3000-4999
-    Generators.frequency[U16]([as (USize, Generator[U16]):
-      (1, Generators.u16(1000, 1003))
-      (1, Generators.u16(1007, 1014))
-      (4, Generators.u16(3000, 4999))
-    ])
+    Generators.frequency[U16](
+      [ as (USize, Generator[U16]):
+        (1, Generators.u16(1000, 1003))
+        (1, Generators.u16(1007, 1014))
+        (4, Generators.u16(3000, 4999))
+      ])
 
   fun property(sample: U16, h: PropertyHelper) =>
-    let payload: Array[U8] val = recover val
-      [as U8: (sample >> 8).u8(); sample.u8()]
-    end
+    let payload: Array[U8] val =
+      recover val
+        [as U8: (sample >> 8).u8(); sample.u8()]
+      end
     (let status, _) = _CloseStatusExtractor.from_payload(payload)
     // Verify the extracted code matches the input regardless of type
-    let extracted_code = match \exhaustive\ status
+    let extracted_code =
+      match \exhaustive\ status
       | let s: CloseNormal => s.code()
       | let s: CloseGoingAway => s.code()
       | let s: CloseProtocolError => s.code()

--- a/mare/_test_fragment_reassembler.pony
+++ b/mare/_test_fragment_reassembler.pony
@@ -96,12 +96,13 @@ class \nodoc\ iso _TestReassemblerMaxSize is UnitTest
 
   fun apply(h: TestHelper) =>
     let reassembler = _FragmentReassembler
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](100)
-      var i: USize = 0
-      while i < 100 do a.push(0x41); i = i + 1 end
-      a
-    end
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](100)
+        var i: USize = 0
+        while i < 100 do a.push(0x41); i = i + 1 end
+        a
+      end
     match \exhaustive\ reassembler.frame(true, 0x02, payload, 50) // max=50
     | let err: _ReassemblyError =>
       h.assert_is[CloseCode](CloseMessageTooBig, err.code)
@@ -163,38 +164,42 @@ class \nodoc\ iso _TestReassemblerPropertyRoundtrip is Property1[USize]
 
   fun property(total_size: USize, h: PropertyHelper) ? =>
     // Build a payload
-    let full_payload = recover val
-      let a = Array[U8](total_size)
-      var i: USize = 0
-      while i < total_size do
-        a.push((i % 256).u8())
-        i = i + 1
+    let full_payload =
+      recover val
+        let a = Array[U8](total_size)
+        var i: USize = 0
+        while i < total_size do
+          a.push((i % 256).u8())
+          i = i + 1
+        end
+        a
       end
-      a
-    end
 
     // Split into 3 fragments
     let split1 = total_size / 3
     let split2 = (total_size * 2) / 3
 
-    let frag1 = recover val
-      let a = Array[U8](split1)
-      var i: USize = 0
-      while i < split1 do a.push(full_payload(i)?); i = i + 1 end
-      a
-    end
-    let frag2 = recover val
-      let a = Array[U8](split2 - split1)
-      var i: USize = split1
-      while i < split2 do a.push(full_payload(i)?); i = i + 1 end
-      a
-    end
-    let frag3 = recover val
-      let a = Array[U8](total_size - split2)
-      var i: USize = split2
-      while i < total_size do a.push(full_payload(i)?); i = i + 1 end
-      a
-    end
+    let frag1 =
+      recover val
+        let a = Array[U8](split1)
+        var i: USize = 0
+        while i < split1 do a.push(full_payload(i)?); i = i + 1 end
+        a
+      end
+    let frag2 =
+      recover val
+        let a = Array[U8](split2 - split1)
+        var i: USize = split1
+        while i < split2 do a.push(full_payload(i)?); i = i + 1 end
+        a
+      end
+    let frag3 =
+      recover val
+        let a = Array[U8](total_size - split2)
+        var i: USize = split2
+        while i < total_size do a.push(full_payload(i)?); i = i + 1 end
+        a
+      end
 
     let reassembler = _FragmentReassembler
     match \exhaustive\ reassembler.frame(false, 0x02, frag1, total_size + 1)

--- a/mare/_test_frame_encoder.pony
+++ b/mare/_test_frame_encoder.pony
@@ -79,15 +79,16 @@ class \nodoc\ iso _TestFrameEncoderLength16Bit is UnitTest
 
   fun apply(h: TestHelper) ? =>
     // Create 200-byte payload
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](200)
-      var i: USize = 0
-      while i < 200 do
-        a.push(0x41)
-        i = i + 1
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](200)
+        var i: USize = 0
+        while i < 200 do
+          a.push(0x41)
+          i = i + 1
+        end
+        a
       end
-      a
-    end
     let frame = _FrameEncoder.binary(payload)
     h.assert_eq[U8](0x82, frame(0)?)
     // Length indicator: 126
@@ -105,15 +106,16 @@ class \nodoc\ iso _TestFrameEncoderLength64Bit is UnitTest
   fun apply(h: TestHelper) ? =>
     // Create 65536-byte payload
     let size: USize = 65536
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](size)
-      var i: USize = 0
-      while i < size do
-        a.push(0x42)
-        i = i + 1
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](size)
+        var i: USize = 0
+        while i < size do
+          a.push(0x42)
+          i = i + 1
+        end
+        a
       end
-      a
-    end
     let frame = _FrameEncoder.binary(payload)
     h.assert_eq[U8](0x82, frame(0)?)
     // Length indicator: 127
@@ -199,29 +201,30 @@ class \nodoc\ iso _TestFrameEncoderPropertyRoundtrip is Property1[USize]
     let payload_size = frame.size() - payload_offset
 
     // Build masked frame
-    let result = recover iso
-      let r = Array[U8](header_size + 4 + payload_size)
-      // Copy first byte unchanged
-      r.push(b0)
-      // Set MASK bit on second byte
-      r.push(b1 or 0x80)
-      // Copy extended length bytes if any
-      var i: USize = 2
-      while i < header_size do
-        r.push(frame(i)?)
-        i = i + 1
+    let result =
+      recover iso
+        let r = Array[U8](header_size + 4 + payload_size)
+        // Copy first byte unchanged
+        r.push(b0)
+        // Set MASK bit on second byte
+        r.push(b1 or 0x80)
+        // Copy extended length bytes if any
+        var i: USize = 2
+        while i < header_size do
+          r.push(frame(i)?)
+          i = i + 1
+        end
+        // Insert mask key
+        r.push(mask_key(0)?)
+        r.push(mask_key(1)?)
+        r.push(mask_key(2)?)
+        r.push(mask_key(3)?)
+        // Mask payload
+        var j: USize = 0
+        while j < payload_size do
+          r.push(frame(payload_offset + j)? xor mask_key(j % 4)?)
+          j = j + 1
+        end
+        r
       end
-      // Insert mask key
-      r.push(mask_key(0)?)
-      r.push(mask_key(1)?)
-      r.push(mask_key(2)?)
-      r.push(mask_key(3)?)
-      // Mask payload
-      var j: USize = 0
-      while j < payload_size do
-        r.push(frame(payload_offset + j)? xor mask_key(j % 4)?)
-        j = j + 1
-      end
-      r
-    end
     consume result

--- a/mare/_test_frame_parser.pony
+++ b/mare/_test_frame_parser.pony
@@ -25,25 +25,25 @@ primitive \nodoc\ _TestFrameHelper
         frame.push(0x80 or payload_size.u8())
       elseif payload_size <= 65535 then
         frame.push(0x80 or 126)
-        frame.>push((payload_size >> 8).u8())
+        frame .> push((payload_size >> 8).u8())
           .push((payload_size and 0xFF).u8())
       else
         frame.push(0x80 or 127)
-        frame.>push((payload_size >> 56).u8())
-          .>push(((payload_size >> 48) and 0xFF).u8())
-          .>push(((payload_size >> 40) and 0xFF).u8())
-          .>push(((payload_size >> 32) and 0xFF).u8())
-          .>push(((payload_size >> 24) and 0xFF).u8())
-          .>push(((payload_size >> 16) and 0xFF).u8())
-          .>push(((payload_size >> 8) and 0xFF).u8())
+        frame .> push((payload_size >> 56).u8())
+          .> push(((payload_size >> 48) and 0xFF).u8())
+          .> push(((payload_size >> 40) and 0xFF).u8())
+          .> push(((payload_size >> 32) and 0xFF).u8())
+          .> push(((payload_size >> 24) and 0xFF).u8())
+          .> push(((payload_size >> 16) and 0xFF).u8())
+          .> push(((payload_size >> 8) and 0xFF).u8())
           .push((payload_size and 0xFF).u8())
       end
 
       // Mask key
       try
-        frame.>push(mask_key(0)?)
-          .>push(mask_key(1)?)
-          .>push(mask_key(2)?)
+        frame .> push(mask_key(0)?)
+          .> push(mask_key(1)?)
+          .> push(mask_key(2)?)
           .push(mask_key(3)?)
 
         // Masked payload
@@ -76,17 +76,17 @@ primitive \nodoc\ _TestFrameHelper
         frame.push(payload_size.u8())
       elseif payload_size <= 65535 then
         frame.push(126)
-        frame.>push((payload_size >> 8).u8())
+        frame .> push((payload_size >> 8).u8())
           .push((payload_size and 0xFF).u8())
       else
         frame.push(127)
-        frame.>push((payload_size >> 56).u8())
-          .>push(((payload_size >> 48) and 0xFF).u8())
-          .>push(((payload_size >> 40) and 0xFF).u8())
-          .>push(((payload_size >> 32) and 0xFF).u8())
-          .>push(((payload_size >> 24) and 0xFF).u8())
-          .>push(((payload_size >> 16) and 0xFF).u8())
-          .>push(((payload_size >> 8) and 0xFF).u8())
+        frame .> push((payload_size >> 56).u8())
+          .> push(((payload_size >> 48) and 0xFF).u8())
+          .> push(((payload_size >> 40) and 0xFF).u8())
+          .> push(((payload_size >> 32) and 0xFF).u8())
+          .> push(((payload_size >> 24) and 0xFF).u8())
+          .> push(((payload_size >> 16) and 0xFF).u8())
+          .> push(((payload_size >> 8) and 0xFF).u8())
           .push((payload_size and 0xFF).u8())
       end
 
@@ -99,8 +99,8 @@ class \nodoc\ iso _TestFrameParserText is UnitTest
   fun name(): String => "frame_parser/text"
 
   fun apply(h: TestHelper) ? =>
-    let frame = _TestFrameHelper.masked_frame(
-      true, 0x01, "Hello".array())
+    let frame =
+      _TestFrameHelper.masked_frame(true, 0x01, "Hello".array())
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
@@ -151,8 +151,9 @@ class \nodoc\ iso _TestFrameParserPong is UnitTest
   fun name(): String => "frame_parser/pong"
 
   fun apply(h: TestHelper) ? =>
-    let frame = _TestFrameHelper.masked_frame(
-      true, 0x0A, recover val Array[U8] end)
+    let frame =
+      _TestFrameHelper.masked_frame(
+        true, 0x0A, recover val Array[U8] end)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
@@ -187,8 +188,9 @@ class \nodoc\ iso _TestFrameParserCloseEmpty is UnitTest
   fun name(): String => "frame_parser/close_empty"
 
   fun apply(h: TestHelper) ? =>
-    let frame = _TestFrameHelper.masked_frame(
-      true, 0x08, recover val Array[U8] end)
+    let frame =
+      _TestFrameHelper.masked_frame(
+        true, 0x08, recover val Array[U8] end)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
@@ -252,12 +254,13 @@ class \nodoc\ iso _TestFrameParserLength16Bit is UnitTest
   fun name(): String => "frame_parser/length_16bit"
 
   fun apply(h: TestHelper) ? =>
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](200)
-      var i: USize = 0
-      while i < 200 do a.push(0x41); i = i + 1 end
-      a
-    end
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](200)
+        var i: USize = 0
+        while i < 200 do a.push(0x41); i = i + 1 end
+        a
+      end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
@@ -273,12 +276,13 @@ class \nodoc\ iso _TestFrameParserLength64Bit is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let size: USize = 65536
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](size)
-      var i: USize = 0
-      while i < size do a.push(0x42); i = i + 1 end
-      a
-    end
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](size)
+        var i: USize = 0
+        while i < size do a.push(0x42); i = i + 1 end
+        a
+      end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
@@ -297,17 +301,18 @@ class \nodoc\ iso _TestFrameParserLength64BitMsbSet is UnitTest
     // The 8-byte extended length is [0x80 0x00 0x00 0x00 0x00 0x01 0x00 0x00],
     // which has bit 63 set. This must be rejected before attempting to read
     // that many payload bytes.
-    let raw: Array[U8] val = recover val
-      let f = Array[U8]
-      f.push(0x80 or 0x02) // FIN + binary
-      f.push(0x80 or 127)  // MASK + 64-bit length indicator
-      // 8-byte extended length with MSB set
-      f.>push(0x80).>push(0x00).>push(0x00).>push(0x00)
-        .>push(0x00).>push(0x01).>push(0x00).push(0x00)
-      // Mask key
-      f.>push(0x00).>push(0x00).>push(0x00).push(0x00)
-      f
-    end
+    let raw: Array[U8] val =
+      recover val
+        let f = Array[U8]
+        f.push(0x80 or 0x02) // FIN + binary
+        f.push(0x80 or 127)  // MASK + 64-bit length indicator
+        // 8-byte extended length with MSB set
+        f .> push(0x80) .> push(0x00) .> push(0x00) .> push(0x00)
+          .> push(0x00) .> push(0x01) .> push(0x00) .> push(0x00)
+        // Mask key
+          .> push(0x00) .> push(0x00) .> push(0x00) .> push(0x00)
+        f
+      end
     let parser = _FrameParser
     match \exhaustive\ parser.parse(raw)
     | let frames: Array[_ParsedFrame val] val =>
@@ -321,8 +326,9 @@ class \nodoc\ iso _TestFrameParserUnmasked is UnitTest
   fun name(): String => "frame_parser/unmasked_rejected"
 
   fun apply(h: TestHelper) =>
-    let frame = _TestFrameHelper.unmasked_frame(
-      true, 0x01, "Hello".array())
+    let frame =
+      _TestFrameHelper.unmasked_frame(
+        true, 0x01, "Hello".array())
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
@@ -337,13 +343,15 @@ class \nodoc\ iso _TestFrameParserNonZeroRsv is UnitTest
 
   fun apply(h: TestHelper) =>
     // Build frame with RSV1 set (0x40)
-    let raw = recover val
-      let f = Array[U8]
-      f.push(0x80 or 0x40 or 0x01) // FIN + RSV1 + text
-      f.push(0x80 or 0x00) // MASK + 0 length
-      f.>push(0x00).>push(0x00).>push(0x00).push(0x00) // mask key
-      f
-    end
+    let raw =
+      recover val
+        let f = Array[U8]
+        f.push(0x80 or 0x40 or 0x01) // FIN + RSV1 + text
+        f.push(0x80 or 0x00) // MASK + 0 length
+        // mask key
+        f .> push(0x00) .> push(0x00) .> push(0x00) .> push(0x00)
+        f
+      end
     let parser = _FrameParser
     match \exhaustive\ parser.parse(raw)
     | let frames: Array[_ParsedFrame val] val =>
@@ -357,8 +365,9 @@ class \nodoc\ iso _TestFrameParserFragmentedControl is UnitTest
   fun name(): String => "frame_parser/fragmented_control"
 
   fun apply(h: TestHelper) =>
-    let frame = _TestFrameHelper.masked_frame(
-      false, 0x09, recover val Array[U8] end)
+    let frame =
+      _TestFrameHelper.masked_frame(
+        false, 0x09, recover val Array[U8] end)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
@@ -372,12 +381,13 @@ class \nodoc\ iso _TestFrameParserControlTooLarge is UnitTest
   fun name(): String => "frame_parser/control_too_large"
 
   fun apply(h: TestHelper) =>
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](126)
-      var i: USize = 0
-      while i < 126 do a.push(0x00); i = i + 1 end
-      a
-    end
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](126)
+        var i: USize = 0
+        while i < 126 do a.push(0x00); i = i + 1 end
+        a
+      end
     let frame = _TestFrameHelper.masked_frame(true, 0x09, payload)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
@@ -392,8 +402,9 @@ class \nodoc\ iso _TestFrameParserUnknownOpcode is UnitTest
   fun name(): String => "frame_parser/unknown_opcode"
 
   fun apply(h: TestHelper) =>
-    let frame = _TestFrameHelper.masked_frame(
-      true, 0x03, recover val Array[U8] end)
+    let frame =
+      _TestFrameHelper.masked_frame(
+        true, 0x03, recover val Array[U8] end)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)
     | let frames: Array[_ParsedFrame val] val =>
@@ -407,8 +418,8 @@ class \nodoc\ iso _TestFrameParserIncremental is UnitTest
   fun name(): String => "frame_parser/incremental"
 
   fun apply(h: TestHelper) ? =>
-    let full_frame = _TestFrameHelper.masked_frame(
-      true, 0x01, "Hi".array())
+    let full_frame =
+      _TestFrameHelper.masked_frame(true, 0x01, "Hi".array())
     let parser = _FrameParser
 
     // Feed one byte at a time
@@ -440,18 +451,20 @@ class \nodoc\ iso _TestFrameParserMultipleFrames is UnitTest
   fun name(): String => "frame_parser/multiple_frames"
 
   fun apply(h: TestHelper) ? =>
-    let frame1 = _TestFrameHelper.masked_frame(
-      true, 0x01, "Hi".array())
-    let frame2 = _TestFrameHelper.masked_frame(
-      true, 0x02, recover val [as U8: 0x01] end)
+    let frame1 =
+      _TestFrameHelper.masked_frame(true, 0x01, "Hi".array())
+    let frame2 =
+      _TestFrameHelper.masked_frame(
+        true, 0x02, recover val [as U8: 0x01] end)
 
     // Concatenate both frames
-    let combined: Array[U8] val = recover val
-      let c = Array[U8](frame1.size() + frame2.size())
-      for b in frame1.values() do c.push(b) end
-      for b in frame2.values() do c.push(b) end
-      c
-    end
+    let combined: Array[U8] val =
+      recover val
+        let c = Array[U8](frame1.size() + frame2.size())
+        for b in frame1.values() do c.push(b) end
+        for b in frame2.values() do c.push(b) end
+        c
+      end
 
     let parser = _FrameParser
     match \exhaustive\ parser.parse(combined)
@@ -467,12 +480,12 @@ class \nodoc\ iso _TestFrameParserCloseValidCodes is Property1[U16]
   fun name(): String => "frame_parser/close_valid_codes"
 
   fun gen(): Generator[U16] =>
-    Generators.frequency[U16]([
-      as WeightedGenerator[U16]:
-      (1, Generators.u16(where min = 1000, max = 1003))
-      (1, Generators.u16(where min = 1007, max = 1014))
-      (1, Generators.u16(where min = 3000, max = 4999))
-    ])
+    Generators.frequency[U16](
+      [ as WeightedGenerator[U16]:
+        (1, Generators.u16(where min = 1000, max = 1003))
+        (1, Generators.u16(where min = 1007, max = 1014))
+        (1, Generators.u16(where min = 3000, max = 4999))
+      ])
 
   fun property(code: U16, h: PropertyHelper) ? =>
     let payload: Array[U8] val =
@@ -494,13 +507,13 @@ class \nodoc\ iso _TestFrameParserCloseInvalidCodes is Property1[U16]
   fun name(): String => "frame_parser/close_invalid_codes"
 
   fun gen(): Generator[U16] =>
-    Generators.frequency[U16]([
-      as WeightedGenerator[U16]:
-      (1, Generators.u16(where min = 0, max = 999))
-      (1, Generators.u16(where min = 1004, max = 1006))
-      (1, Generators.u16(where min = 1015, max = 2999))
-      (1, Generators.u16(where min = 5000, max = 65535))
-    ])
+    Generators.frequency[U16](
+      [ as WeightedGenerator[U16]:
+        (1, Generators.u16(where min = 0, max = 999))
+        (1, Generators.u16(where min = 1004, max = 1006))
+        (1, Generators.u16(where min = 1015, max = 2999))
+        (1, Generators.u16(where min = 5000, max = 65535))
+      ])
 
   fun property(code: U16, h: PropertyHelper) =>
     let payload: Array[U8] val =
@@ -519,18 +532,18 @@ class \nodoc\ iso _TestFrameParserCloseMixedCodes is Property1[U16]
   fun name(): String => "frame_parser/close_mixed_codes"
 
   fun gen(): Generator[U16] =>
-    Generators.frequency[U16]([
-      as WeightedGenerator[U16]:
-      // Valid ranges
-      (1, Generators.u16(where min = 1000, max = 1003))
-      (1, Generators.u16(where min = 1007, max = 1014))
-      (1, Generators.u16(where min = 3000, max = 4999))
-      // Invalid ranges
-      (1, Generators.u16(where min = 0, max = 999))
-      (1, Generators.u16(where min = 1004, max = 1006))
-      (1, Generators.u16(where min = 1015, max = 2999))
-      (1, Generators.u16(where min = 5000, max = 65535))
-    ])
+    Generators.frequency[U16](
+      [ as WeightedGenerator[U16]:
+        // Valid ranges
+        (1, Generators.u16(where min = 1000, max = 1003))
+        (1, Generators.u16(where min = 1007, max = 1014))
+        (1, Generators.u16(where min = 3000, max = 4999))
+        // Invalid ranges
+        (1, Generators.u16(where min = 0, max = 999))
+        (1, Generators.u16(where min = 1004, max = 1006))
+        (1, Generators.u16(where min = 1015, max = 2999))
+        (1, Generators.u16(where min = 5000, max = 65535))
+      ])
 
   fun property(code: U16, h: PropertyHelper) =>
     let valid =
@@ -558,12 +571,13 @@ class \nodoc\ iso _TestFrameParserPropertyRandom is Property1[USize]
     Generators.usize(where min = 0, max = 200)
 
   fun property(payload_size: USize, h: PropertyHelper) ? =>
-    let payload: Array[U8] val = recover val
-      let a = Array[U8](payload_size)
-      var i: USize = 0
-      while i < payload_size do a.push((i % 256).u8()); i = i + 1 end
-      a
-    end
+    let payload: Array[U8] val =
+      recover val
+        let a = Array[U8](payload_size)
+        var i: USize = 0
+        while i < payload_size do a.push((i % 256).u8()); i = i + 1 end
+        a
+      end
     let frame = _TestFrameHelper.masked_frame(true, 0x02, payload)
     let parser = _FrameParser
     match \exhaustive\ parser.parse(frame)

--- a/mare/_test_handshake_parser.pony
+++ b/mare/_test_handshake_parser.pony
@@ -13,18 +13,18 @@ primitive \nodoc\ _TestHandshakeHelper
   =>
     """Build a valid HTTP upgrade request."""
     let s = String(512)
-      .>append("GET ")
-      .>append(uri)
-      .>append(" HTTP/1.1\r\n")
-      .>append("Host: localhost\r\n")
-      .>append("Upgrade: websocket\r\n")
-      .>append("Connection: Upgrade\r\n")
-      .>append("Sec-WebSocket-Key: ")
-      .>append(key)
-      .>append("\r\n")
-      .>append("Sec-WebSocket-Version: 13\r\n")
-      .>append(extra_headers)
-      .>append("\r\n")
+      .> append("GET ")
+      .> append(uri)
+      .> append(" HTTP/1.1\r\n")
+      .> append("Host: localhost\r\n")
+      .> append("Upgrade: websocket\r\n")
+      .> append("Connection: Upgrade\r\n")
+      .> append("Sec-WebSocket-Key: ")
+      .> append(key)
+      .> append("\r\n")
+      .> append("Sec-WebSocket-Version: 13\r\n")
+      .> append(extra_headers)
+      .> append("\r\n")
     s.clone().iso_array()
 
 class \nodoc\ iso _TestHandshakeValid is UnitTest
@@ -54,12 +54,12 @@ class \nodoc\ iso _TestHandshakeRemainingBytes is UnitTest
     let request_data = _TestHandshakeHelper.valid_request()
     // Append extra bytes after the request
     let extra: Array[U8] val = recover val [as U8: 0x81; 0x85] end
-    let combined = recover iso
-      let c = Array[U8]
-      c.append(consume request_data)
-      c.append(extra)
-      c
-    end
+    let combined =
+      recover iso
+        Array[U8]
+          .> append(consume request_data)
+          .> append(extra)
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume combined, 8192)
     | let result: _HandshakeResult =>
@@ -89,17 +89,18 @@ class \nodoc\ iso _TestHandshakeInvalidMethod is UnitTest
   fun name(): String => "handshake/invalid_method"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("POST / HTTP/1.1\r\n")
-        .>append("Host: localhost\r\n")
-        .>append("Upgrade: websocket\r\n")
-        .>append("Connection: Upgrade\r\n")
-        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
-        .>append("Sec-WebSocket-Version: 13\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("POST / HTTP/1.1\r\n")
+          .> append("Host: localhost\r\n")
+          .> append("Upgrade: websocket\r\n")
+          .> append("Connection: Upgrade\r\n")
+          .> append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+          .> append("Sec-WebSocket-Version: 13\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | HandshakeInvalidHTTP => None // expected
@@ -113,16 +114,17 @@ class \nodoc\ iso _TestHandshakeMissingHost is UnitTest
   fun name(): String => "handshake/missing_host"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("GET / HTTP/1.1\r\n")
-        .>append("Upgrade: websocket\r\n")
-        .>append("Connection: Upgrade\r\n")
-        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
-        .>append("Sec-WebSocket-Version: 13\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("GET / HTTP/1.1\r\n")
+          .> append("Upgrade: websocket\r\n")
+          .> append("Connection: Upgrade\r\n")
+          .> append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+          .> append("Sec-WebSocket-Version: 13\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | HandshakeMissingHost => None // expected
@@ -136,16 +138,17 @@ class \nodoc\ iso _TestHandshakeMissingUpgrade is UnitTest
   fun name(): String => "handshake/missing_upgrade"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("GET / HTTP/1.1\r\n")
-        .>append("Host: localhost\r\n")
-        .>append("Connection: Upgrade\r\n")
-        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
-        .>append("Sec-WebSocket-Version: 13\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("GET / HTTP/1.1\r\n")
+          .> append("Host: localhost\r\n")
+          .> append("Connection: Upgrade\r\n")
+          .> append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+          .> append("Sec-WebSocket-Version: 13\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | HandshakeMissingUpgrade => None // expected
@@ -159,17 +162,18 @@ class \nodoc\ iso _TestHandshakeWrongVersion is UnitTest
   fun name(): String => "handshake/wrong_version"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("GET / HTTP/1.1\r\n")
-        .>append("Host: localhost\r\n")
-        .>append("Upgrade: websocket\r\n")
-        .>append("Connection: Upgrade\r\n")
-        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
-        .>append("Sec-WebSocket-Version: 8\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("GET / HTTP/1.1\r\n")
+          .> append("Host: localhost\r\n")
+          .> append("Upgrade: websocket\r\n")
+          .> append("Connection: Upgrade\r\n")
+          .> append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+          .> append("Sec-WebSocket-Version: 8\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | HandshakeWrongVersion => None // expected
@@ -183,16 +187,17 @@ class \nodoc\ iso _TestHandshakeMissingKey is UnitTest
   fun name(): String => "handshake/missing_key"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("GET / HTTP/1.1\r\n")
-        .>append("Host: localhost\r\n")
-        .>append("Upgrade: websocket\r\n")
-        .>append("Connection: Upgrade\r\n")
-        .>append("Sec-WebSocket-Version: 13\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("GET / HTTP/1.1\r\n")
+          .> append("Host: localhost\r\n")
+          .> append("Upgrade: websocket\r\n")
+          .> append("Connection: Upgrade\r\n")
+          .> append("Sec-WebSocket-Version: 13\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | HandshakeMissingKey => None // expected
@@ -206,8 +211,9 @@ class \nodoc\ iso _TestHandshakeInvalidKeyBadBase64 is UnitTest
   fun name(): String => "handshake/invalid_key_bad_base64"
 
   fun apply(h: TestHelper) =>
-    let data = _TestHandshakeHelper.valid_request(
-      where key = "!!!invalid-key!!!!!!!!!==")
+    let data =
+      _TestHandshakeHelper.valid_request(
+        where key = "!!!invalid-key!!!!!!!!!==")
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume data, 8192)
     | HandshakeInvalidKey => None // expected
@@ -236,17 +242,18 @@ class \nodoc\ iso _TestHandshakeCaseInsensitive is UnitTest
   fun name(): String => "handshake/case_insensitive"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("GET / HTTP/1.1\r\n")
-        .>append("Host: localhost\r\n")
-        .>append("upgrade: WebSocket\r\n")
-        .>append("connection: Upgrade\r\n")
-        .>append("sec-websocket-key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
-        .>append("sec-websocket-version: 13\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("GET / HTTP/1.1\r\n")
+          .> append("Host: localhost\r\n")
+          .> append("upgrade: WebSocket\r\n")
+          .> append("connection: Upgrade\r\n")
+          .> append("sec-websocket-key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+          .> append("sec-websocket-version: 13\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | let result: _HandshakeResult =>
@@ -267,15 +274,16 @@ class \nodoc\ iso _TestHandshakeIncremental is UnitTest
     let split_at = full_size / 2
     let parser = _HandshakeParser
 
-    let first_half = recover iso
-      let a = Array[U8](split_at)
-      var i: USize = 0
-      while i < split_at do
-        try a.push(full_request(i)?) else _Unreachable() end
-        i = i + 1
+    let first_half =
+      recover iso
+        let a = Array[U8](split_at)
+        var i: USize = 0
+        while i < split_at do
+          try a.push(full_request(i)?) else _Unreachable() end
+          i = i + 1
+        end
+        a
       end
-      a
-    end
 
     match \exhaustive\ parser(consume first_half, 8192)
     | _HandshakeNeedMore => None // expected
@@ -283,15 +291,16 @@ class \nodoc\ iso _TestHandshakeIncremental is UnitTest
     | let err: HandshakeError => h.fail("unexpected error")
     end
 
-    let second_half = recover iso
-      let a = Array[U8](full_size - split_at)
-      var i: USize = split_at
-      while i < full_size do
-        try a.push(full_request(i)?) else _Unreachable() end
-        i = i + 1
+    let second_half =
+      recover iso
+        let a = Array[U8](full_size - split_at)
+        var i: USize = split_at
+        while i < full_size do
+          try a.push(full_request(i)?) else _Unreachable() end
+          i = i + 1
+        end
+        a
       end
-      a
-    end
 
     match \exhaustive\ parser(consume second_half, 8192)
     | let result: _HandshakeResult =>
@@ -327,17 +336,18 @@ class \nodoc\ iso _TestHandshakeConnectionMultiToken is UnitTest
   fun name(): String => "handshake/connection_multi_token"
 
   fun apply(h: TestHelper) =>
-    let request: Array[U8] iso = recover iso
-      let s = String(256)
-        .>append("GET / HTTP/1.1\r\n")
-        .>append("Host: localhost\r\n")
-        .>append("Upgrade: websocket\r\n")
-        .>append("Connection: keep-alive, Upgrade\r\n")
-        .>append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
-        .>append("Sec-WebSocket-Version: 13\r\n")
-        .>append("\r\n")
-      s.clone().iso_array()
-    end
+    let request: Array[U8] iso =
+      recover iso
+        let s = String(256)
+          .> append("GET / HTTP/1.1\r\n")
+          .> append("Host: localhost\r\n")
+          .> append("Upgrade: websocket\r\n")
+          .> append("Connection: keep-alive, Upgrade\r\n")
+          .> append("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n")
+          .> append("Sec-WebSocket-Version: 13\r\n")
+          .> append("\r\n")
+        s.clone().iso_array()
+      end
     let parser = _HandshakeParser
     match \exhaustive\ parser(consume request, 8192)
     | let result: _HandshakeResult =>

--- a/mare/_unreachable.pony
+++ b/mare/_unreachable.pony
@@ -11,9 +11,9 @@ primitive _Unreachable
     @fprintf(
       @pony_os_stderr(),
       ("The unreachable was reached in %s at line %s\n" +
-       "Please open an issue at " +
-       "https://github.com/ponylang/mare/issues")
-       .cstring(),
+        "Please open an issue at " +
+        "https://github.com/ponylang/mare/issues")
+        .cstring(),
       loc.file().cstring(),
       loc.line().string().cstring())
     @exit(1)

--- a/mare/_utf8_validator.pony
+++ b/mare/_utf8_validator.pony
@@ -8,7 +8,9 @@ primitive _Utf8Validator
   """
 
   fun is_valid(data: Array[U8] box): Bool =>
-    """Return true if `data` is valid UTF-8."""
+    """
+    Return true if `data` is valid UTF-8.
+    """
     var i: USize = 0
     let size = data.size()
 

--- a/mare/close_code.pony
+++ b/mare/close_code.pony
@@ -10,73 +10,137 @@ type CloseCode is
   | CloseInternalError )
 
 primitive CloseNormal is Stringable
-  """Normal closure (1000). The connection fulfilled its purpose."""
+  """
+  Normal closure (1000). The connection fulfilled its purpose.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1000
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1000 Normal Closure".clone()
 
 primitive CloseGoingAway is Stringable
-  """Going away (1001). The endpoint is shutting down."""
+  """
+  Going away (1001). The endpoint is shutting down.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1001
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1001 Going Away".clone()
 
 primitive CloseProtocolError is Stringable
-  """Protocol error (1002). A protocol violation was detected."""
+  """
+  Protocol error (1002). A protocol violation was detected.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1002
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1002 Protocol Error".clone()
 
 primitive CloseUnsupportedData is Stringable
-  """Unsupported data (1003). An unsupported data type was received."""
+  """
+  Unsupported data (1003). An unsupported data type was received.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1003
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1003 Unsupported Data".clone()
 
 primitive CloseInvalidPayload is Stringable
-  """Invalid payload (1007). A message payload was not valid."""
+  """
+  Invalid payload (1007). A message payload was not valid.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1007
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1007 Invalid Payload".clone()
 
 primitive ClosePolicyViolation is Stringable
-  """Policy violation (1008). A policy was violated."""
+  """
+  Policy violation (1008). A policy was violated.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1008
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1008 Policy Violation".clone()
 
 primitive CloseMessageTooBig is Stringable
-  """Message too big (1009). A message exceeded the size limit."""
+  """
+  Message too big (1009). A message exceeded the size limit.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1009
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1009 Message Too Big".clone()
 
 primitive CloseInternalError is Stringable
-  """Internal error (1011). An unexpected server error occurred."""
+  """
+  Internal error (1011). An unexpected server error occurred.
+  """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1011
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1011 Internal Error".clone()

--- a/mare/close_status.pony
+++ b/mare/close_status.pony
@@ -15,11 +15,17 @@ primitive CloseNoStatusReceived is Stringable
   Indicates the close frame had no payload. This is an indicator code that
   must never appear on the wire — it exists only for the application callback.
   """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1005
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1005 No Status Received".clone()
 
 primitive CloseAbnormalClosure is Stringable
@@ -30,11 +36,17 @@ primitive CloseAbnormalClosure is Stringable
   indicator code that must never appear on the wire — it exists only for the
   application callback.
   """
+
   fun code(): U16 =>
-    """Returns the RFC 6455 numeric close code."""
+    """
+    Returns the RFC 6455 numeric close code.
+    """
     1006
+
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the code and name."""
+    """
+    Returns a human-readable representation including the code and name.
+    """
     "1006 Abnormal Closure".clone()
 
 class val OtherCloseCode is Stringable
@@ -48,13 +60,19 @@ class val OtherCloseCode is Stringable
   let _code: U16
 
   new val create(code': U16) =>
-    """Create an OtherCloseCode wrapping the given numeric code."""
+    """
+    Create an OtherCloseCode wrapping the given numeric code.
+    """
     _code = code'
 
   fun code(): U16 =>
-    """Returns the raw numeric close code."""
+    """
+    Returns the raw numeric close code.
+    """
     _code
 
   fun string(): String iso^ =>
-    """Returns a human-readable representation including the numeric code."""
+    """
+    Returns a human-readable representation including the numeric code.
+    """
     (_code.string() + " Other").clone()

--- a/mare/handshake_error.pony
+++ b/mare/handshake_error.pony
@@ -10,21 +10,36 @@ type HandshakeError is
   | HandshakeAcceptKeyFailed )
 
 primitive HandshakeRequestTooLarge is Stringable
-  """The HTTP upgrade request exceeded the maximum allowed size."""
+  """
+  The HTTP upgrade request exceeded the maximum allowed size.
+  """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Handshake request too large".clone()
 
 primitive HandshakeInvalidHTTP is Stringable
-  """The HTTP request line was malformed or not a GET request."""
+  """
+  The HTTP request line was malformed or not a GET request.
+  """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Invalid HTTP request".clone()
 
 primitive HandshakeMissingHost is Stringable
-  """The required Host header was missing."""
+  """
+  The required Host header was missing.
+  """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Missing Host header".clone()
 
 primitive HandshakeMissingUpgrade is Stringable
@@ -32,20 +47,33 @@ primitive HandshakeMissingUpgrade is Stringable
   The required Upgrade and Connection headers were missing or had
   incorrect values.
   """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Missing or invalid Upgrade/Connection headers".clone()
 
 primitive HandshakeWrongVersion is Stringable
-  """The Sec-WebSocket-Version header was not 13."""
+  """
+  The Sec-WebSocket-Version header was not 13.
+  """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Wrong WebSocket version (expected 13)".clone()
 
 primitive HandshakeMissingKey is Stringable
-  """The Sec-WebSocket-Key header was missing."""
+  """
+  The Sec-WebSocket-Key header was missing.
+  """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Missing Sec-WebSocket-Key header".clone()
 
 primitive HandshakeInvalidKey is Stringable
@@ -53,8 +81,11 @@ primitive HandshakeInvalidKey is Stringable
   The Sec-WebSocket-Key header was not a valid base64-encoded
   16-byte value.
   """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Invalid Sec-WebSocket-Key (must be base64-encoded 16 bytes)".clone()
 
 primitive HandshakeAcceptKeyFailed is Stringable
@@ -65,6 +96,9 @@ primitive HandshakeAcceptKeyFailed is Stringable
   could not be taken. A server that reports this answers 500 rather than
   400, because nothing about the client's request was wrong.
   """
+
   fun string(): String iso^ =>
-    """Returns a human-readable description of this error."""
+    """
+    Returns a human-readable description of this error.
+    """
     "Could not compute Sec-WebSocket-Accept".clone()

--- a/mare/upgrade_request.pony
+++ b/mare/upgrade_request.pony
@@ -9,7 +9,9 @@ class val UpgradeRequest
   let _headers: Array[(String val, String val)] val
 
   new val create(uri': String, headers': Array[(String val, String val)] val) =>
-    """Create an upgrade request with the given URI and headers."""
+    """
+    Create an upgrade request with the given URI and headers.
+    """
     uri = uri'
     _headers = headers'
 

--- a/mare/web_socket_config.pony
+++ b/mare/web_socket_config.pony
@@ -23,7 +23,9 @@ class val WebSocketConfig
     max_message_size': USize = 1_048_576,
     max_handshake_size': USize = 8192)
   =>
-    """Create WebSocket configuration with optional overrides."""
+    """
+    Create WebSocket configuration with optional overrides.
+    """
     host = host'
     port = port'
     max_message_size = max_message_size'

--- a/mare/web_socket_lifecycle_event_receiver.pony
+++ b/mare/web_socket_lifecycle_event_receiver.pony
@@ -29,15 +29,21 @@ trait WebSocketLifecycleEventReceiver
     true
 
   fun ref on_open(request: UpgradeRequest val) =>
-    """Called after the WebSocket handshake completes successfully."""
+    """
+    Called after the WebSocket handshake completes successfully.
+    """
     None
 
   fun ref on_text_message(data: String val) =>
-    """Called when a complete text message is received."""
+    """
+    Called when a complete text message is received.
+    """
     None
 
   fun ref on_binary_message(data: Array[U8] val) =>
-    """Called when a complete binary message is received."""
+    """
+    Called when a complete binary message is received.
+    """
     None
 
   fun ref on_closed(
@@ -59,13 +65,19 @@ trait WebSocketLifecycleEventReceiver
     None
 
   fun ref on_throttled() =>
-    """Called when backpressure is applied on the connection."""
+    """
+    Called when backpressure is applied on the connection.
+    """
     None
 
   fun ref on_unthrottled() =>
-    """Called when backpressure is released on the connection."""
+    """
+    Called when backpressure is released on the connection.
+    """
     None
 
   fun ref on_idle_timeout() =>
-    """Called when the connection's idle timeout fires."""
+    """
+    Called when the connection's idle timeout fires.
+    """
     None

--- a/mare/web_socket_server.pony
+++ b/mare/web_socket_server.pony
@@ -52,7 +52,9 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     server_actor: WebSocketServerActor ref,
     config: WebSocketConfig val)
   =>
-    """Create a plain WebSocket (WS) connection handler."""
+    """
+    Create a plain WebSocket (WS) connection handler.
+    """
     _lifecycle_event_receiver = server_actor
     _config = config
     _state = _Handshaking
@@ -66,7 +68,9 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     server_actor: WebSocketServerActor ref,
     config: WebSocketConfig val)
   =>
-    """Create a secure WebSocket (WSS) connection handler."""
+    """
+    Create a secure WebSocket (WSS) connection handler.
+    """
     _lifecycle_event_receiver = server_actor
     _config = config
     _state = _Handshaking
@@ -75,13 +79,16 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
         auth, ssl_ctx, fd, server_actor, this)
 
   // -- Public send API --
-
   fun ref send_text(data: String val) =>
-    """Send a text message to the client."""
+    """
+    Send a text message to the client.
+    """
     _state.send_text(this, data)
 
   fun ref send_binary(data: Array[U8] val) =>
-    """Send a binary message to the client."""
+    """
+    Send a binary message to the client.
+    """
     _state.send_binary(this, data)
 
   fun ref close(
@@ -98,7 +105,6 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     _state.close(this, code, reason)
 
   // -- lori ServerLifecycleEventReceiver --
-
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
   fun ref _on_started() => None
@@ -134,14 +140,18 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
   fun ref _on_timer(token: lori.TimerToken) => None
 
   // -- Internal methods called by state classes --
-
   fun ref _set_state(state: _ConnectionState) =>
-    """Transition to a new connection state."""
+    """
+    Transition to a new connection state.
+    """
     _state = state
 
   fun ref _feed_handshake(data: Array[U8] iso) =>
-    """Process incoming data during the handshake phase."""
-    let max_size = match \exhaustive\ _config
+    """
+    Process incoming data during the handshake phase.
+    """
+    let max_size =
+      match \exhaustive\ _config
       | let c: WebSocketConfig val => c.max_handshake_size
       | None => _Unreachable(); return
       end
@@ -171,7 +181,8 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     | let err: HandshakeError =>
       match err
       | HandshakeWrongVersion =>
-        _send_http_error("426 Upgrade Required",
+        _send_http_error(
+          "426 Upgrade Required",
           "Sec-WebSocket-Version: 13\r\n")
       | HandshakeAcceptKeyFailed =>
         _send_http_error("500 Internal Server Error")
@@ -183,12 +194,16 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     end
 
   fun ref _feed_frames(data: Array[U8] iso) =>
-    """Process incoming frame data in the Open state."""
+    """
+    Process incoming frame data in the Open state.
+    """
     let data_val: Array[U8] val = consume data
     _feed_frames_from_val(data_val)
 
   fun ref _feed_frames_from_val(data: Array[U8] val) =>
-    """Process incoming frame data from a val array."""
+    """
+    Process incoming frame data from a val array.
+    """
     match \exhaustive\ _frame_parser.parse(data)
     | let frames: Array[_ParsedFrame val] val =>
       for frame in frames.values() do
@@ -206,7 +221,9 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     end
 
   fun ref _feed_frames_closing(data: Array[U8] iso) =>
-    """Process incoming frame data in the Closing state."""
+    """
+    Process incoming frame data in the Closing state.
+    """
     let data_val: Array[U8] val = consume data
     match \exhaustive\ _frame_parser.parse(data_val)
     | let frames: Array[_ParsedFrame val] val =>
@@ -235,7 +252,9 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     end
 
   fun ref _dispatch_frame(frame: _ParsedFrame val) =>
-    """Dispatch a parsed frame by opcode in the Open state."""
+    """
+    Dispatch a parsed frame by opcode in the Open state.
+    """
     match frame.opcode
     | 0x09 =>
       // Ping — auto-respond with pong
@@ -257,7 +276,8 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
       _state = _Closed
     else
       // Data frame (text, binary, continuation) — reassemble
-      let max_size = match \exhaustive\ _config
+      let max_size =
+        match \exhaustive\ _config
         | let c: WebSocketConfig val => c.max_message_size
         | None => _Unreachable(); return
         end
@@ -291,31 +311,37 @@ class WebSocketServer is lori.ServerLifecycleEventReceiver
     _tcp_connection.send(data)
 
   fun ref _send_101_response(accept_key: String val) =>
-    """Send the HTTP 101 Switching Protocols response."""
-    let response: String val = recover val
-      String(256)
-        .>append("HTTP/1.1 101 Switching Protocols\r\n")
-        .>append("Upgrade: websocket\r\n")
-        .>append("Connection: Upgrade\r\n")
-        .>append("Sec-WebSocket-Accept: ")
-        .>append(accept_key)
-        .>append("\r\n\r\n")
-    end
+    """
+    Send the HTTP 101 Switching Protocols response.
+    """
+    let response: String val =
+      recover val
+        String(256)
+          .> append("HTTP/1.1 101 Switching Protocols\r\n")
+          .> append("Upgrade: websocket\r\n")
+          .> append("Connection: Upgrade\r\n")
+          .> append("Sec-WebSocket-Accept: ")
+          .> append(accept_key)
+          .> append("\r\n\r\n")
+      end
     _tcp_connection.send(response)
 
   fun ref _send_http_error(
     status: String val,
     extra_headers: String val = "")
   =>
-    """Send an HTTP error response and close."""
-    let response: String val = recover val
-      String(256)
-        .>append("HTTP/1.1 ")
-        .>append(status)
-        .>append("\r\n")
-        .>append(extra_headers)
-        .>append("Content-Length: 0\r\n\r\n")
-    end
+    """
+    Send an HTTP error response and close.
+    """
+    let response: String val =
+      recover val
+        String(256)
+          .> append("HTTP/1.1 ")
+          .> append(status)
+          .> append("\r\n")
+          .> append(extra_headers)
+          .> append("Content-Length: 0\r\n\r\n")
+      end
     _tcp_connection.send(response)
 
   fun ref _fire_on_open(request: UpgradeRequest val) =>

--- a/mare/web_socket_server_actor.pony
+++ b/mare/web_socket_server_actor.pony
@@ -30,8 +30,12 @@ trait tag WebSocketServerActor is
   """
 
   fun ref _websocket(): WebSocketServer
-    """Return the protocol instance owned by this actor."""
+    """
+    Return the protocol instance owned by this actor.
+    """
 
   fun ref _connection(): lori.TCPConnection =>
-    """Delegates to the protocol's TCP connection."""
+    """
+    Delegates to the protocol's TCP connection.
+    """
     _websocket()._connection()


### PR DESCRIPTION
Add pony-lint CI workflow and Makefile lint target. Fix all
style violations found by pony-lint: assignment-indent,
array-literal-format, blank-lines, dot-spacing, prefer-chaining,
public-docstring, call-argument-format, and method-declaration-format.
